### PR TITLE
feat: add Specs panel to Droid feature

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -157,6 +157,7 @@
 
   "droid.features.models": "BYOK Models",
   "droid.features.helpers": "Helpers",
+  "droid.features.specs": "Specs",
   "droid.helpers.title": "Helpers",
   "droid.helpers.skipLogin.title": "Try Skip Login",
   "droid.helpers.skipLogin.notSet": "Not set",
@@ -171,6 +172,11 @@
   "droid.helpers.skipLogin.linuxPermanent": "Add the export command to ~/.bashrc or ~/.profile, then reopen Terminal.",
   "droid.helpers.skipLogin.windowsPermanent": "Open System Settings → System → About → Advanced system settings → Environment Variables, then add a new user variable.",
   "droid.helpers.skipLogin.restartWarning": "Refresh environment variables and restart Droid for changes to take effect",
+
+  "droid.specs.title": "Specs",
+  "droid.specs.noSpecs": "No specs found",
+  "droid.specs.noSpecsHint": "Specs will appear here when available in ~/.factory/specs",
+  "droid.specs.selectSpecHint": "Select a spec from the list to view its content",
 
   "common.copied": "Copied",
 

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -157,6 +157,7 @@
 
   "droid.features.models": "BYOK 模型",
   "droid.features.helpers": "辅助工具",
+  "droid.features.specs": "Specs",
   "droid.helpers.title": "辅助工具",
   "droid.helpers.skipLogin.title": "尝试跳过登录",
   "droid.helpers.skipLogin.notSet": "未设置",
@@ -171,6 +172,11 @@
   "droid.helpers.skipLogin.linuxPermanent": "将 export 命令添加到 ~/.bashrc 或 ~/.profile，然后重新打开终端。",
   "droid.helpers.skipLogin.windowsPermanent": "打开系统设置 → 系统 → 关于 → 高级系统设置 → 环境变量，添加新的用户变量。",
   "droid.helpers.skipLogin.restartWarning": "设置后需刷新环境变量并重启 Droid 生效",
+
+  "droid.specs.title": "Specs",
+  "droid.specs.noSpecs": "没有找到 Specs",
+  "droid.specs.noSpecsHint": "Specs 将在 ~/.factory/specs 中可用时显示在这里",
+  "droid.specs.selectSpecHint": "从列表中选择一个 Spec 查看内容",
 
   "common.copied": "已复制",
 

--- a/src-tauri/src/bindings.rs
+++ b/src-tauri/src/bindings.rs
@@ -1,7 +1,7 @@
 use tauri_specta::{collect_commands, Builder};
 
 pub fn generate_bindings() -> Builder<tauri::Wry> {
-    use crate::commands::{channel, config, env, notifications, preferences, quick_pane, recovery};
+    use crate::commands::{channel, config, env, notifications, preferences, quick_pane, recovery, specs};
 
     Builder::<tauri::Wry>::new().commands(collect_commands![
         preferences::greet,
@@ -35,6 +35,8 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         env::get_env_var,
         env::set_env_var,
         env::remove_env_var,
+        specs::list_specs,
+        specs::read_spec,
     ])
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,3 +10,4 @@ pub mod notifications;
 pub mod preferences;
 pub mod quick_pane;
 pub mod recovery;
+pub mod specs;

--- a/src-tauri/src/commands/specs.rs
+++ b/src-tauri/src/commands/specs.rs
@@ -1,0 +1,154 @@
+//! Specs management commands.
+//!
+//! Handles reading spec files from ~/.factory/specs directory.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+/// Spec file metadata
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecFile {
+    /// File name (e.g., "2025-12-18-ui.md")
+    pub name: String,
+    /// Full path to the file
+    pub path: String,
+    /// File content
+    pub content: String,
+    /// Last modified timestamp in milliseconds
+    pub modified_at: f64,
+}
+
+/// Gets the path to the specs directory (~/.factory/specs).
+fn get_specs_dir() -> Result<PathBuf, String> {
+    let home_dir = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
+    Ok(home_dir.join(".factory").join("specs"))
+}
+
+/// Lists all spec files from ~/.factory/specs directory.
+/// Returns files sorted by modification time (newest first).
+#[tauri::command]
+#[specta::specta]
+pub async fn list_specs() -> Result<Vec<SpecFile>, String> {
+    log::debug!("Listing specs from ~/.factory/specs");
+    let specs_dir = get_specs_dir()?;
+
+    if !specs_dir.exists() {
+        log::info!("Specs directory does not exist: {specs_dir:?}");
+        return Ok(Vec::new());
+    }
+
+    let mut specs: Vec<SpecFile> = Vec::new();
+
+    let entries = fs::read_dir(&specs_dir).map_err(|e| {
+        log::error!("Failed to read specs directory: {e}");
+        format!("Failed to read specs directory: {e}")
+    })?;
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                log::warn!("Failed to read directory entry: {e}");
+                continue;
+            }
+        };
+
+        let path = entry.path();
+
+        // Only process markdown files
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+
+        let metadata = match fs::metadata(&path) {
+            Ok(m) => m,
+            Err(e) => {
+                log::warn!("Failed to read file metadata for {path:?}: {e}");
+                continue;
+            }
+        };
+
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let modified_at = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as f64)
+            .unwrap_or(0.0);
+
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("Failed to read file content for {path:?}: {e}");
+                continue;
+            }
+        };
+
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        specs.push(SpecFile {
+            name,
+            path: path.to_string_lossy().to_string(),
+            content,
+            modified_at,
+        });
+    }
+
+    // Sort by modified time, newest first
+    specs.sort_by(|a, b| b.modified_at.partial_cmp(&a.modified_at).unwrap_or(std::cmp::Ordering::Equal));
+
+    log::info!("Found {} spec files", specs.len());
+    Ok(specs)
+}
+
+/// Reads a single spec file by path.
+#[tauri::command]
+#[specta::specta]
+pub async fn read_spec(path: String) -> Result<SpecFile, String> {
+    log::debug!("Reading spec file: {path}");
+
+    let path_buf = PathBuf::from(&path);
+
+    if !path_buf.exists() {
+        return Err("Spec file not found".to_string());
+    }
+
+    let metadata = fs::metadata(&path_buf).map_err(|e| {
+        log::error!("Failed to read file metadata: {e}");
+        format!("Failed to read file metadata: {e}")
+    })?;
+
+    let modified_at = metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as f64)
+        .unwrap_or(0.0);
+
+    let content = fs::read_to_string(&path_buf).map_err(|e| {
+        log::error!("Failed to read file content: {e}");
+        format!("Failed to read file content: {e}")
+    })?;
+
+    let name = path_buf
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+
+    Ok(SpecFile {
+        name,
+        path,
+        content,
+        modified_at,
+    })
+}

--- a/src/components/droid/DroidFeatureList.tsx
+++ b/src/components/droid/DroidFeatureList.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { Cpu, LifeBuoy } from 'lucide-react'
+import { Cpu, LifeBuoy, FileText } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { useUIStore } from '@/store/ui-store'
@@ -14,6 +14,7 @@ interface FeatureItem {
 const features: FeatureItem[] = [
   { id: 'models', labelKey: 'droid.features.models', icon: Cpu },
   { id: 'helpers', labelKey: 'droid.features.helpers', icon: LifeBuoy },
+  { id: 'specs', labelKey: 'droid.features.specs', icon: FileText },
 ]
 
 export function DroidFeatureList() {

--- a/src/components/droid/SpecsPage.tsx
+++ b/src/components/droid/SpecsPage.tsx
@@ -1,0 +1,133 @@
+import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { RefreshCw, FileText, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+import { commands, type SpecFile } from '@/lib/bindings'
+
+export function SpecsPage() {
+  const { t } = useTranslation()
+  const [specs, setSpecs] = useState<SpecFile[]>([])
+  const [selectedSpec, setSelectedSpec] = useState<SpecFile | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadSpecs = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await commands.listSpecs()
+      if (result.status === 'ok') {
+        setSpecs(result.data)
+        // Auto-select first spec if none selected
+        if (result.data.length > 0 && !selectedSpec) {
+          setSelectedSpec(result.data[0])
+        }
+      } else {
+        setError(result.error)
+      }
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadSpecs()
+  }, [])
+
+  const formatDate = (timestamp: number) => {
+    const date = new Date(timestamp)
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between p-4 border-b">
+        <h1 className="text-xl font-semibold">{t('droid.specs.title')}</h1>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={loadSpecs}
+          disabled={loading}
+        >
+          <RefreshCw className={cn('h-4 w-4 mr-2', loading && 'animate-spin')} />
+          {t('common.refresh')}
+        </Button>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Specs List */}
+        <div className="w-64 border-r flex flex-col">
+          <ScrollArea className="flex-1">
+            <div className="p-2 space-y-1">
+              {loading && specs.length === 0 ? (
+                <div className="flex items-center justify-center p-4 text-muted-foreground">
+                  {t('common.loading')}
+                </div>
+              ) : error ? (
+                <div className="p-4 text-destructive text-sm">{error}</div>
+              ) : specs.length === 0 ? (
+                <div className="flex flex-col items-center justify-center p-4 text-muted-foreground text-sm">
+                  <FileText className="h-8 w-8 mb-2 opacity-50" />
+                  <p>{t('droid.specs.noSpecs')}</p>
+                  <p className="text-xs mt-1">{t('droid.specs.noSpecsHint')}</p>
+                </div>
+              ) : (
+                specs.map(spec => (
+                  <button
+                    key={spec.path}
+                    onClick={() => setSelectedSpec(spec)}
+                    className={cn(
+                      'w-full text-start p-2 rounded-md hover:bg-accent transition-colors',
+                      selectedSpec?.path === spec.path && 'bg-accent'
+                    )}
+                  >
+                    <div className="font-medium text-sm truncate">{spec.name}</div>
+                    <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+                      <Clock className="h-3 w-3" />
+                      {formatDate(spec.modifiedAt)}
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Spec Content */}
+        <div className="flex-1 flex flex-col">
+          {selectedSpec ? (
+            <>
+              <div className="p-4 border-b">
+                <h2 className="font-medium">{selectedSpec.name}</h2>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {formatDate(selectedSpec.modifiedAt)}
+                </p>
+              </div>
+              <ScrollArea className="flex-1">
+                <div className="p-4">
+                  <pre className="whitespace-pre-wrap text-sm font-mono">
+                    {selectedSpec.content}
+                  </pre>
+                </div>
+              </ScrollArea>
+            </>
+          ) : (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              <p>{t('droid.specs.selectSpecHint')}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/droid/index.ts
+++ b/src/components/droid/index.ts
@@ -1,2 +1,3 @@
 export { DroidFeatureList } from './DroidFeatureList'
 export { DroidHelpersPage } from './DroidHelpersPage'
+export { SpecsPage } from './SpecsPage'

--- a/src/components/layout/MainWindowContent.tsx
+++ b/src/components/layout/MainWindowContent.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/lib/utils'
 import { ModelConfigPage } from '@/components/models'
-import { DroidHelpersPage } from '@/components/droid'
+import { DroidHelpersPage, SpecsPage } from '@/components/droid'
 import { ChannelDetail, ChannelDialog } from '@/components/channels'
 import { useUIStore } from '@/store/ui-store'
 import { useChannelStore } from '@/store/channel-store'
@@ -48,6 +48,9 @@ export function MainWindowContent({
     if (currentView === 'droid') {
       if (droidSubView === 'models') {
         return <ModelConfigPage />
+      }
+      if (droidSubView === 'specs') {
+        return <SpecsPage />
       }
       return <DroidHelpersPage />
     }

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -335,6 +335,29 @@ async setEnvVar(name: string, value: string) : Promise<void> {
  */
 async removeEnvVar(name: string) : Promise<void> {
     await TAURI_INVOKE("remove_env_var", { name });
+},
+/**
+ * Lists all spec files from ~/.factory/specs directory.
+ * Returns files sorted by modification time (newest first).
+ */
+async listSpecs() : Promise<Result<SpecFile[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_specs") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Reads a single spec file by path.
+ */
+async readSpec(path: string) : Promise<Result<SpecFile, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("read_spec", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -348,6 +371,10 @@ async removeEnvVar(name: string) : Promise<void> {
 
 /** user-defined types **/
 
+/**
+ * Spec file from ~/.factory/specs directory
+ */
+export type SpecFile = { name: string; path: string; content: string; modifiedAt: number }
 /**
  * Application preferences that persist to disk.
  * Only contains settings that should be saved between sessions.

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 
 type NavigationView = 'droid' | 'channels'
-export type DroidSubView = 'models' | 'helpers'
+export type DroidSubView = 'models' | 'helpers' | 'specs'
 
 interface UIState {
   leftSidebarVisible: boolean


### PR DESCRIPTION
## Summary
- Add a new Specs feature to the Droid panel that displays spec files from ~/.factory/specs directory
- List view sorted by modification time (newest first)
- Content viewer for selected spec files with refresh capability
- Full i18n support (English and Chinese)

## Test plan
- [ ] Verify Specs tab appears in Droid panel navigation
- [ ] Confirm spec files from ~/.factory/specs are listed correctly
- [ ] Verify sorting by modification time (newest first)
- [ ] Test selecting a spec file displays its content
- [ ] Test refresh button reloads the spec list
- [ ] Verify i18n strings work in both English and Chinese

🤖 Generated with [Claude Code](https://claude.com/claude-code)