### PR TITLE
feat: Codex CLI config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ xattr -cr /Applications/DroidGear.app
 - **AI 开发集成** - OpenCode 工具集成
 - **配置管理** - 服务商/认证配置的加载和保存
 
+### Codex 支持
+
+- **Codex CLI 集成** - Codex 配置 Profile 管理
+- **配置管理** - 认证与 `config.toml` 的加载和保存（`~/.codex`）
+- **管理入口** - 在 Codex 入口下提供 MCP 服务器 / 会话 / 终端 管理子页
+
 ### 其他功能
 
 - **跳过登录辅助** - 辅助跳过登录流程

--- a/README_EN.md
+++ b/README_EN.md
@@ -57,6 +57,12 @@ Run the installer directly.
 - **AI Development Integration** - OpenCode tool integration
 - **Configuration Management** - Load and save provider/auth configurations
 
+### Codex Support
+
+- **Codex CLI Integration** - Manage Codex configuration profiles
+- **Configuration Management** - Load and save auth/config.toml (`~/.codex`)
+- **Management Pages** - MCP servers / sessions / terminal subpages under Codex
+
 ### Other Features
 
 - **Skip Login Helper** - Helper for skipping login flow

--- a/locales/en.json
+++ b/locales/en.json
@@ -84,6 +84,11 @@
   "common.reset": "Reset",
   "common.cancel": "Cancel",
   "common.save": "Save",
+  "common.saved": "Saved",
+  "common.unsaved": "Unsaved",
+  "common.exists": "Exists",
+  "common.missing": "Missing",
+  "common.copy": "Copy",
   "common.add": "Add",
   "common.create": "Create",
   "common.edit": "Edit",
@@ -160,6 +165,7 @@
 
   "sidebar.channels": "Channels",
   "sidebar.droid": "Droid",
+  "sidebar.codex": "Codex",
   "sidebar.models": "Models",
   "sidebar.selectModelHint": "Select a model from the main panel to edit",
   "sidebar.unsavedChanges.title": "Unsaved Changes",
@@ -502,5 +508,45 @@
   "opencode.actions.saveSuccess": "Profile saved successfully",
   "opencode.actions.apply": "Apply Profile",
   "opencode.actions.applyConfirm": "Apply this profile? This will update your OpenCode configuration files (opencode.json and auth.json).",
-  "opencode.actions.applySuccess": "Profile applied successfully"
+  "opencode.actions.applySuccess": "Profile applied successfully",
+
+  "codex.title": "Codex",
+
+  "codex.features.title": "Codex",
+  "codex.features.profiles": "Profiles",
+  "codex.features.hint": "Manage Codex CLI configuration (auth.json / config.toml).",
+
+  "codex.profile.active": "Active",
+  "codex.profile.noProfile": "No profile available",
+  "codex.profile.select": "Select Profile",
+  "codex.profile.name": "Name",
+  "codex.profile.description": "Description",
+  "codex.profile.create": "Create Profile",
+  "codex.profile.createPlaceholder": "New profile name",
+  "codex.profile.createAction": "Create",
+  "codex.profile.duplicate": "Duplicate Profile",
+  "codex.profile.duplicatePlaceholder": "Duplicate name",
+  "codex.profile.duplicateAction": "Duplicate",
+  "codex.profile.delete": "Delete Profile",
+  "codex.profile.deleteAction": "Delete",
+  "codex.profile.created": "Profile created",
+  "codex.profile.duplicated": "Profile duplicated",
+  "codex.profile.deleted": "Profile deleted",
+
+  "codex.live.status": "Live Config",
+  "codex.live.authPath": "auth.json",
+  "codex.live.configPath": "config.toml",
+
+  "codex.auth.apiKey": "OPENAI_API_KEY",
+  "codex.auth.apiKeyPlaceholder": "sk-...",
+  "codex.auth.apiKeyHint": "Saved to ~/.codex/auth.json (local only).",
+
+  "codex.configToml": "config.toml",
+  "codex.configTomlHint": "Saved to ~/.codex/config.toml. Valid TOML is required.",
+
+  "codex.actions.apply": "Apply",
+  "codex.actions.applyConfirm": "Apply this profile? This will update your Codex CLI configuration files (~/.codex/auth.json and ~/.codex/config.toml).",
+  "codex.actions.applied": "Applied",
+  "codex.actions.loadFromLive": "Load Live",
+  "codex.actions.loadedFromLive": "Loaded from live config"
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -84,6 +84,11 @@
   "common.reset": "重置",
   "common.cancel": "取消",
   "common.save": "保存",
+  "common.saved": "已保存",
+  "common.unsaved": "未保存",
+  "common.exists": "存在",
+  "common.missing": "缺失",
+  "common.copy": "复制",
   "common.add": "添加",
   "common.create": "创建",
   "common.edit": "编辑",
@@ -160,6 +165,7 @@
 
   "sidebar.channels": "渠道",
   "sidebar.droid": "Droid",
+  "sidebar.codex": "Codex",
   "sidebar.models": "模型",
   "sidebar.selectModelHint": "从主面板选择一个模型进行编辑",
   "sidebar.unsavedChanges.title": "未保存的更改",
@@ -502,5 +508,45 @@
   "opencode.actions.saveSuccess": "Profile 保存成功",
   "opencode.actions.apply": "应用 Profile",
   "opencode.actions.applyConfirm": "应用此 Profile？这将更新您的 OpenCode 配置文件（opencode.json 和 auth.json）。",
-  "opencode.actions.applySuccess": "Profile 应用成功"
+  "opencode.actions.applySuccess": "Profile 应用成功",
+
+  "codex.title": "Codex",
+
+  "codex.features.title": "Codex",
+  "codex.features.profiles": "Profile 管理",
+  "codex.features.hint": "管理 Codex CLI 配置（auth.json / config.toml）。",
+
+  "codex.profile.active": "当前生效",
+  "codex.profile.noProfile": "暂无可用 Profile",
+  "codex.profile.select": "选择 Profile",
+  "codex.profile.name": "名称",
+  "codex.profile.description": "描述",
+  "codex.profile.create": "创建 Profile",
+  "codex.profile.createPlaceholder": "新 Profile 名称",
+  "codex.profile.createAction": "创建",
+  "codex.profile.duplicate": "复制 Profile",
+  "codex.profile.duplicatePlaceholder": "复制后的名称",
+  "codex.profile.duplicateAction": "复制",
+  "codex.profile.delete": "删除 Profile",
+  "codex.profile.deleteAction": "删除",
+  "codex.profile.created": "Profile 已创建",
+  "codex.profile.duplicated": "Profile 已复制",
+  "codex.profile.deleted": "Profile 已删除",
+
+  "codex.live.status": "当前配置",
+  "codex.live.authPath": "auth.json",
+  "codex.live.configPath": "config.toml",
+
+  "codex.auth.apiKey": "OPENAI_API_KEY",
+  "codex.auth.apiKeyPlaceholder": "sk-...",
+  "codex.auth.apiKeyHint": "将写入 ~/.codex/auth.json（仅本地存储）。",
+
+  "codex.configToml": "config.toml",
+  "codex.configTomlHint": "将写入 ~/.codex/config.toml，需为合法 TOML。",
+
+  "codex.actions.apply": "应用",
+  "codex.actions.applyConfirm": "确定应用该 Profile？这将更新 Codex CLI 配置文件（~/.codex/auth.json 与 ~/.codex/config.toml）。",
+  "codex.actions.applied": "已应用",
+  "codex.actions.loadFromLive": "读取当前配置",
+  "codex.actions.loadedFromLive": "已从当前配置读取"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tauri-specta",
+ "toml 0.8.2",
  "uuid",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 json_comments = "0.2"
 tauri-plugin-pty = "0.2.0"
+toml = "0.8"
 
 # Type-safe Tauri command bindings
 specta = { version = "=2.0.0-rc.22", features = ["derive", "serde_json"] }

--- a/src-tauri/src/bindings.rs
+++ b/src-tauri/src/bindings.rs
@@ -2,7 +2,8 @@ use tauri_specta::{collect_commands, Builder};
 
 pub fn generate_bindings() -> Builder<tauri::Wry> {
     use crate::commands::{
-        channel, config, env, mcp, notifications, opencode, preferences, recovery, sessions, specs,
+        channel, config, codex, env, mcp, notifications, opencode, preferences, recovery, sessions,
+        specs,
     };
 
     Builder::<tauri::Wry>::new().commands(collect_commands![
@@ -58,6 +59,16 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         mcp::save_mcp_server,
         mcp::delete_mcp_server,
         mcp::toggle_mcp_server,
+        codex::list_codex_profiles,
+        codex::get_codex_profile,
+        codex::save_codex_profile,
+        codex::delete_codex_profile,
+        codex::duplicate_codex_profile,
+        codex::create_default_codex_profile,
+        codex::get_active_codex_profile_id,
+        codex::apply_codex_profile,
+        codex::get_codex_config_status,
+        codex::read_codex_current_config,
         opencode::list_opencode_profiles,
         opencode::get_opencode_profile,
         opencode::save_opencode_profile,

--- a/src-tauri/src/commands/codex.rs
+++ b/src-tauri/src/commands/codex.rs
@@ -1,0 +1,432 @@
+//! Codex CLI 配置管理命令。
+//!
+//! 提供 Profile CRUD，并支持将 Profile 应用到 `~/.codex/auth.json` 与 `~/.codex/config.toml`。
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use specta::Type;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// Codex Profile（用于在 DroidGear 内部保存并切换）
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexProfile {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub auth: HashMap<String, Value>,
+    #[serde(default)]
+    pub config_toml: String,
+}
+
+/// Codex Live 配置状态
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexConfigStatus {
+    pub auth_exists: bool,
+    pub config_exists: bool,
+    pub auth_path: String,
+    pub config_path: String,
+}
+
+/// 当前 Codex Live 配置（从 `~/.codex/*` 读取）
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexCurrentConfig {
+    #[serde(default)]
+    pub auth: HashMap<String, Value>,
+    #[serde(default)]
+    pub config_toml: String,
+}
+
+// ============================================================================
+// Path Helpers
+// ============================================================================
+
+fn get_home_dir() -> Result<PathBuf, String> {
+    dirs::home_dir().ok_or("Failed to get home directory".to_string())
+}
+
+fn get_droidgear_codex_dir() -> Result<PathBuf, String> {
+    Ok(get_home_dir()?.join(".droidgear").join("codex"))
+}
+
+/// `~/.droidgear/codex/profiles/`
+fn get_profiles_dir() -> Result<PathBuf, String> {
+    let dir = get_droidgear_codex_dir()?.join("profiles");
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("Failed to create codex profiles directory: {e}"))?;
+    }
+    Ok(dir)
+}
+
+/// `~/.droidgear/codex/active-profile.txt`
+fn get_active_profile_path() -> Result<PathBuf, String> {
+    let dir = get_droidgear_codex_dir()?;
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("Failed to create codex directory: {e}"))?;
+    }
+    Ok(dir.join("active-profile.txt"))
+}
+
+/// `~/.codex/`
+fn get_codex_config_dir() -> Result<PathBuf, String> {
+    let dir = get_home_dir()?.join(".codex");
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("Failed to create codex config directory: {e}"))?;
+    }
+    Ok(dir)
+}
+
+fn get_codex_auth_path() -> Result<PathBuf, String> {
+    Ok(get_codex_config_dir()?.join("auth.json"))
+}
+
+fn get_codex_config_path() -> Result<PathBuf, String> {
+    Ok(get_codex_config_dir()?.join("config.toml"))
+}
+
+fn validate_profile_id(id: &str) -> Result<(), String> {
+    let ok = id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if ok && !id.is_empty() {
+        Ok(())
+    } else {
+        Err("Invalid profile id".to_string())
+    }
+}
+
+fn get_profile_path(id: &str) -> Result<PathBuf, String> {
+    validate_profile_id(id)?;
+    Ok(get_profiles_dir()?.join(format!("{id}.json")))
+}
+
+// ============================================================================
+// File Helpers
+// ============================================================================
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create directory: {e}"))?;
+        }
+    }
+
+    let temp_path = path.with_extension("tmp");
+    std::fs::write(&temp_path, bytes).map_err(|e| format!("Failed to write file: {e}"))?;
+    std::fs::rename(&temp_path, path).map_err(|e| {
+        let _ = std::fs::remove_file(&temp_path);
+        format!("Failed to finalize file: {e}")
+    })?;
+    Ok(())
+}
+
+fn read_json_object_file(path: &Path) -> Result<HashMap<String, Value>, String> {
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let s =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {e}"))?;
+    if s.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+    let v: Value = serde_json::from_str(&s).map_err(|e| format!("Invalid JSON: {e}"))?;
+    match v {
+        Value::Object(map) => Ok(map.into_iter().collect()),
+        _ => Err("Invalid JSON: expected object".to_string()),
+    }
+}
+
+fn write_json_object_file(path: &Path, obj: &HashMap<String, Value>) -> Result<(), String> {
+    let v = Value::Object(obj.clone().into_iter().collect());
+    let s = serde_json::to_string_pretty(&v).map_err(|e| format!("Failed to serialize JSON: {e}"))?;
+    atomic_write(path, s.as_bytes())
+}
+
+fn read_text_file(path: &Path) -> Result<String, String> {
+    if !path.exists() {
+        return Ok(String::new());
+    }
+    std::fs::read_to_string(path).map_err(|e| format!("Failed to read file: {e}"))
+}
+
+fn validate_toml(text: &str) -> Result<(), String> {
+    if text.trim().is_empty() {
+        return Ok(());
+    }
+    toml::from_str::<toml::Table>(text)
+        .map(|_| ())
+        .map_err(|e| format!("Invalid TOML: {e}"))
+}
+
+fn write_codex_live_atomic(
+    auth: &HashMap<String, Value>,
+    config_toml: &str,
+) -> Result<(), String> {
+    validate_toml(config_toml)?;
+
+    let auth_path = get_codex_auth_path()?;
+    let config_path = get_codex_config_path()?;
+
+    let old_auth = if auth_path.exists() {
+        Some(std::fs::read(&auth_path).map_err(|e| format!("Failed to read auth.json: {e}"))?)
+    } else {
+        None
+    };
+    let old_config = if config_path.exists() {
+        Some(
+            std::fs::read(&config_path).map_err(|e| format!("Failed to read config.toml: {e}"))?,
+        )
+    } else {
+        None
+    };
+
+    // 1) 写 auth.json
+    write_json_object_file(&auth_path, auth)?;
+
+    // 2) 写 config.toml（失败回滚 auth.json 与 config.toml）
+    if let Err(e) = atomic_write(&config_path, config_toml.as_bytes()) {
+        if let Some(bytes) = old_auth {
+            let _ = atomic_write(&auth_path, &bytes);
+        } else {
+            let _ = std::fs::remove_file(&auth_path);
+        }
+        if let Some(bytes) = old_config {
+            let _ = atomic_write(&config_path, &bytes);
+        } else {
+            let _ = std::fs::remove_file(&config_path);
+        }
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Profile Helpers
+// ============================================================================
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn default_codex_template_config() -> String {
+    // 参考 cc-switch 的 Codex 自定义模板，作为 DroidGear 默认 Profile 初始值。
+    r#"model_provider = "custom"
+model = "gpt-5.2"
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+    .to_string()
+}
+
+fn read_profile_file(path: &Path) -> Result<CodexProfile, String> {
+    let s = std::fs::read_to_string(path).map_err(|e| format!("Failed to read profile: {e}"))?;
+    serde_json::from_str::<CodexProfile>(&s).map_err(|e| format!("Invalid profile JSON: {e}"))
+}
+
+fn write_profile_file(profile: &CodexProfile) -> Result<(), String> {
+    let path = get_profile_path(&profile.id)?;
+    let s = serde_json::to_string_pretty(profile)
+        .map_err(|e| format!("Failed to serialize profile JSON: {e}"))?;
+    atomic_write(&path, s.as_bytes())
+}
+
+fn load_profile_by_id(id: &str) -> Result<CodexProfile, String> {
+    let path = get_profile_path(id)?;
+    read_profile_file(&path)
+}
+
+// ============================================================================
+// Tauri Commands
+// ============================================================================
+
+/// 列出所有 Codex Profiles
+#[tauri::command]
+#[specta::specta]
+pub async fn list_codex_profiles() -> Result<Vec<CodexProfile>, String> {
+    let dir = get_profiles_dir()?;
+    let mut profiles = Vec::new();
+
+    for entry in std::fs::read_dir(&dir).map_err(|e| format!("Failed to read profiles dir: {e}"))? {
+        let entry = entry.map_err(|e| format!("Failed to read dir entry: {e}"))?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(p) = read_profile_file(&path) {
+            profiles.push(p);
+        }
+    }
+
+    profiles.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(profiles)
+}
+
+/// 获取指定 Profile
+#[tauri::command]
+#[specta::specta]
+pub async fn get_codex_profile(id: String) -> Result<CodexProfile, String> {
+    load_profile_by_id(&id)
+}
+
+/// 保存 Profile（新建或更新）
+#[tauri::command]
+#[specta::specta]
+pub async fn save_codex_profile(mut profile: CodexProfile) -> Result<(), String> {
+    if profile.id.trim().is_empty() {
+        profile.id = Uuid::new_v4().to_string();
+        profile.created_at = now_rfc3339();
+    } else if get_profile_path(&profile.id)?.exists() {
+        // 保留 created_at
+        if let Ok(old) = load_profile_by_id(&profile.id) {
+            profile.created_at = old.created_at;
+        }
+    } else if profile.created_at.trim().is_empty() {
+        profile.created_at = now_rfc3339();
+    }
+
+    profile.updated_at = now_rfc3339();
+    write_profile_file(&profile)
+}
+
+/// 删除 Profile
+#[tauri::command]
+#[specta::specta]
+pub async fn delete_codex_profile(id: String) -> Result<(), String> {
+    let path = get_profile_path(&id)?;
+    if path.exists() {
+        std::fs::remove_file(&path).map_err(|e| format!("Failed to delete profile: {e}"))?;
+    }
+
+    // 如果删除的是 active profile，则清空
+    if let Ok(active) = get_active_profile_id_internal() {
+        if active.as_deref() == Some(id.as_str()) {
+            let active_path = get_active_profile_path()?;
+            let _ = std::fs::remove_file(active_path);
+        }
+    }
+
+    Ok(())
+}
+
+/// 复制 Profile
+#[tauri::command]
+#[specta::specta]
+pub async fn duplicate_codex_profile(id: String, new_name: String) -> Result<CodexProfile, String> {
+    let mut profile = load_profile_by_id(&id)?;
+    profile.id = Uuid::new_v4().to_string();
+    profile.name = new_name;
+    profile.created_at = now_rfc3339();
+    profile.updated_at = profile.created_at.clone();
+    write_profile_file(&profile)?;
+    Ok(profile)
+}
+
+/// 创建默认 Profile（当无 Profile 时调用）
+#[tauri::command]
+#[specta::specta]
+pub async fn create_default_codex_profile() -> Result<CodexProfile, String> {
+    let id = Uuid::new_v4().to_string();
+    let now = now_rfc3339();
+    let mut auth = HashMap::new();
+    auth.insert("OPENAI_API_KEY".to_string(), Value::String(String::new()));
+
+    let profile = CodexProfile {
+        id,
+        name: "默认".to_string(),
+        description: Some("Codex 自定义模板（需填写 API Key）".to_string()),
+        created_at: now.clone(),
+        updated_at: now,
+        auth,
+        config_toml: default_codex_template_config(),
+    };
+
+    write_profile_file(&profile)?;
+    Ok(profile)
+}
+
+fn get_active_profile_id_internal() -> Result<Option<String>, String> {
+    let path = get_active_profile_path()?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let s = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read active profile id: {e}"))?;
+    let id = s.trim().to_string();
+    if id.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(id))
+    }
+}
+
+/// 读取 active Profile ID
+#[tauri::command]
+#[specta::specta]
+pub async fn get_active_codex_profile_id() -> Result<Option<String>, String> {
+    get_active_profile_id_internal()
+}
+
+fn set_active_profile_id(id: &str) -> Result<(), String> {
+    let path = get_active_profile_path()?;
+    atomic_write(&path, id.as_bytes())
+}
+
+/// 应用指定 Profile 到 `~/.codex/*`
+#[tauri::command]
+#[specta::specta]
+pub async fn apply_codex_profile(id: String) -> Result<(), String> {
+    let profile = load_profile_by_id(&id)?;
+    write_codex_live_atomic(&profile.auth, &profile.config_toml)?;
+    set_active_profile_id(&id)?;
+    Ok(())
+}
+
+/// 获取 Codex Live 配置状态（文件是否存在及路径）
+#[tauri::command]
+#[specta::specta]
+pub async fn get_codex_config_status() -> Result<CodexConfigStatus, String> {
+    let auth_path = get_codex_auth_path()?;
+    let config_path = get_codex_config_path()?;
+    Ok(CodexConfigStatus {
+        auth_exists: auth_path.exists(),
+        config_exists: config_path.exists(),
+        auth_path: auth_path.to_string_lossy().to_string(),
+        config_path: config_path.to_string_lossy().to_string(),
+    })
+}
+
+/// 读取当前 `~/.codex/*` 配置（若不存在则返回空）
+#[tauri::command]
+#[specta::specta]
+pub async fn read_codex_current_config() -> Result<CodexCurrentConfig, String> {
+    let auth_path = get_codex_auth_path()?;
+    let config_path = get_codex_config_path()?;
+
+    let auth = read_json_object_file(&auth_path)?;
+    let config_toml = read_text_file(&config_path)?;
+
+    Ok(CodexCurrentConfig { auth, config_toml })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod channel;
 pub mod config;
+pub mod codex;
 pub mod env;
 pub mod mcp;
 pub mod notifications;

--- a/src/components/codex/CodexConfigPage.tsx
+++ b/src/components/codex/CodexConfigPage.tsx
@@ -1,0 +1,355 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Save, RefreshCw, Upload, Download, Copy } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useCodexStore } from '@/store/codex-store'
+import type { JsonValue } from '@/lib/bindings'
+
+export function CodexConfigPage() {
+  const { t } = useTranslation()
+
+  const profiles = useCodexStore(state => state.profiles)
+  const activeProfileId = useCodexStore(state => state.activeProfileId)
+  const currentProfile = useCodexStore(state => state.currentProfile)
+  const hasChanges = useCodexStore(state => state.hasChanges)
+  const isLoading = useCodexStore(state => state.isLoading)
+  const error = useCodexStore(state => state.error)
+  const configStatus = useCodexStore(state => state.configStatus)
+
+  const loadProfiles = useCodexStore(state => state.loadProfiles)
+  const loadActiveProfileId = useCodexStore(state => state.loadActiveProfileId)
+  const loadConfigStatus = useCodexStore(state => state.loadConfigStatus)
+  const selectProfile = useCodexStore(state => state.selectProfile)
+  const saveProfile = useCodexStore(state => state.saveProfile)
+  const applyProfile = useCodexStore(state => state.applyProfile)
+  const resetChanges = useCodexStore(state => state.resetChanges)
+  const updateProfileName = useCodexStore(state => state.updateProfileName)
+  const updateProfileDescription = useCodexStore(state => state.updateProfileDescription)
+  const updateAuthValue = useCodexStore(state => state.updateAuthValue)
+  const updateConfigToml = useCodexStore(state => state.updateConfigToml)
+  const loadFromLiveConfig = useCodexStore(state => state.loadFromLiveConfig)
+  const setError = useCodexStore(state => state.setError)
+  const duplicateProfile = useCodexStore(state => state.duplicateProfile)
+  const deleteProfile = useCodexStore(state => state.deleteProfile)
+  const createProfile = useCodexStore(state => state.createProfile)
+
+  const [applyConfirmOpen, setApplyConfirmOpen] = useState(false)
+  const [newProfileName, setNewProfileName] = useState('')
+  const [duplicateName, setDuplicateName] = useState('')
+
+  const apiKey = useMemo(() => {
+    const auth = (currentProfile?.auth || {}) as Record<string, JsonValue | undefined>
+    const value = auth.OPENAI_API_KEY
+    return typeof value === 'string' ? value : ''
+  }, [currentProfile])
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      await loadProfiles()
+      await loadActiveProfileId()
+      await loadConfigStatus()
+      if (cancelled) return
+      const state = useCodexStore.getState()
+      if (!state.currentProfile && state.profiles[0]) state.selectProfile(state.profiles[0].id)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [loadActiveProfileId, loadConfigStatus, loadProfiles])
+
+  useEffect(() => {
+    if (error) toast.error(error)
+  }, [error])
+
+  const handleCopyPath = async (text?: string) => {
+    if (!text) return
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success(t('common.copied'))
+    } catch (e) {
+      toast.error(String(e))
+    }
+  }
+
+  const handleCreateProfile = async () => {
+    if (!newProfileName.trim()) return
+    await createProfile(newProfileName.trim())
+    setNewProfileName('')
+    await loadProfiles()
+    toast.success(t('codex.profile.created'))
+  }
+
+  const handleDuplicateProfile = async () => {
+    if (!currentProfile || !duplicateName.trim()) return
+    await duplicateProfile(currentProfile.id, duplicateName.trim())
+    setDuplicateName('')
+    toast.success(t('codex.profile.duplicated'))
+  }
+
+  const handleDeleteProfile = async () => {
+    if (!currentProfile) return
+    await deleteProfile(currentProfile.id)
+    toast.success(t('codex.profile.deleted'))
+  }
+
+  const headerBadges = useMemo(() => {
+    if (!currentProfile) return null
+    const isActive = activeProfileId === currentProfile.id
+    return (
+      <div className="flex items-center gap-2">
+        {isActive && <Badge variant="outline">{t('codex.profile.active')}</Badge>}
+        {hasChanges && <Badge variant="secondary">{t('common.unsaved')}</Badge>}
+      </div>
+    )
+  }, [activeProfileId, currentProfile, hasChanges, t])
+
+  if (!currentProfile) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        <p>{t('codex.profile.noProfile')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-semibold">{t('codex.title')}</h1>
+          {headerBadges}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={async () => {
+              await loadFromLiveConfig()
+              toast.success(t('codex.actions.loadedFromLive'))
+            }}
+          >
+            <Download className="h-4 w-4 mr-2" />
+            {t('codex.actions.loadFromLive')}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={async () => {
+              await saveProfile()
+              toast.success(t('common.saved'))
+            }}
+            disabled={!hasChanges}
+          >
+            <Save className="h-4 w-4 mr-2" />
+            {t('common.save')}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              resetChanges()
+              toast.success(t('common.reset'))
+            }}
+            disabled={!hasChanges}
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            {t('common.reset')}
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => setApplyConfirmOpen(true)}
+            disabled={isLoading}
+          >
+            <Upload className="h-4 w-4 mr-2" />
+            {t('codex.actions.apply')}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>{t('codex.profile.select')}</Label>
+            <Select value={currentProfile.id} onValueChange={selectProfile}>
+              <SelectTrigger>
+                <SelectValue placeholder={t('codex.profile.select')} />
+              </SelectTrigger>
+              <SelectContent>
+                {profiles.map(p => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('codex.profile.name')}</Label>
+            <Input
+              value={currentProfile.name}
+              onChange={e => updateProfileName(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('codex.profile.description')}</Label>
+            <Input
+              value={currentProfile.description ?? ''}
+              onChange={e => updateProfileDescription(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('codex.profile.create')}</Label>
+            <div className="flex gap-2">
+              <Input
+                value={newProfileName}
+                onChange={e => setNewProfileName(e.target.value)}
+                placeholder={t('codex.profile.createPlaceholder')}
+              />
+              <Button variant="secondary" onClick={handleCreateProfile}>
+                {t('codex.profile.createAction')}
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('codex.profile.duplicate')}</Label>
+            <div className="flex gap-2">
+              <Input
+                value={duplicateName}
+                onChange={e => setDuplicateName(e.target.value)}
+                placeholder={t('codex.profile.duplicatePlaceholder')}
+              />
+              <Button variant="secondary" onClick={handleDuplicateProfile}>
+                {t('codex.profile.duplicateAction')}
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('codex.profile.delete')}</Label>
+            <Button variant="destructive" onClick={handleDeleteProfile}>
+              {t('codex.profile.deleteAction')}
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('codex.live.status')}</Label>
+            <div className="text-xs text-muted-foreground space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <span>{t('codex.live.authPath')}</span>
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">
+                    {configStatus?.authExists ? t('common.exists') : t('common.missing')}
+                  </Badge>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleCopyPath(configStatus?.authPath)}
+                    title={t('common.copy')}
+                  >
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <span>{t('codex.live.configPath')}</span>
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">
+                    {configStatus?.configExists ? t('common.exists') : t('common.missing')}
+                  </Badge>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleCopyPath(configStatus?.configPath)}
+                    title={t('common.copy')}
+                  >
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="lg:col-span-2 space-y-4">
+          <div className="space-y-2">
+            <Label>{t('codex.auth.apiKey')}</Label>
+            <Input
+              value={apiKey}
+              onChange={e => updateAuthValue('OPENAI_API_KEY', e.target.value)}
+              placeholder={t('codex.auth.apiKeyPlaceholder')}
+              type="password"
+              autoComplete="off"
+            />
+            <div className="text-xs text-muted-foreground">
+              {t('codex.auth.apiKeyHint')}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t('codex.configToml')}</Label>
+            <Textarea
+              value={currentProfile.configToml}
+              onChange={e => updateConfigToml(e.target.value)}
+              className="min-h-[320px] font-mono text-xs"
+              spellCheck={false}
+            />
+            <div className="text-xs text-muted-foreground">
+              {t('codex.configTomlHint')}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <AlertDialog open={applyConfirmOpen} onOpenChange={setApplyConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('codex.actions.apply')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('codex.actions.applyConfirm')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setError(null)}>
+              {t('common.cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={async () => {
+                await applyProfile(currentProfile.id)
+                setApplyConfirmOpen(false)
+                toast.success(t('codex.actions.applied'))
+              }}
+            >
+              {t('codex.actions.apply')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/components/codex/CodexFeatureList.tsx
+++ b/src/components/codex/CodexFeatureList.tsx
@@ -1,0 +1,111 @@
+import { useTranslation } from 'react-i18next'
+import { useState } from 'react'
+import { Wrench, Plug, MessageSquare, TerminalSquare } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { ActionButton } from '@/components/ui/action-button'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { useUIStore } from '@/store/ui-store'
+import { useCodexStore } from '@/store/codex-store'
+import type { CodexSubView } from '@/store/ui-store'
+
+export function CodexFeatureList() {
+  const { t } = useTranslation()
+  const codexSubView = useUIStore(state => state.codexSubView)
+  const setCodexSubView = useUIStore(state => state.setCodexSubView)
+  const codexHasChanges = useCodexStore(state => state.hasChanges)
+
+  const [pendingSubView, setPendingSubView] = useState<CodexSubView | null>(
+    null
+  )
+
+  const features: {
+    id: CodexSubView
+    labelKey: string
+    icon: React.ElementType
+  }[] = [
+    { id: 'config', labelKey: 'codex.title', icon: Wrench },
+    { id: 'mcp', labelKey: 'droid.features.mcp', icon: Plug },
+    { id: 'sessions', labelKey: 'droid.features.sessions', icon: MessageSquare },
+    { id: 'terminal', labelKey: 'droid.features.terminal', icon: TerminalSquare },
+  ]
+
+  const handleSubViewChange = (view: CodexSubView) => {
+    if (view === codexSubView) return
+
+    if (codexSubView === 'config' && codexHasChanges) {
+      setPendingSubView(view)
+    } else {
+      setCodexSubView(view)
+    }
+  }
+
+  const handleSaveAndSwitch = async () => {
+    await useCodexStore.getState().saveProfile()
+    if (pendingSubView) {
+      setCodexSubView(pendingSubView)
+      setPendingSubView(null)
+    }
+  }
+
+  const handleDiscardAndSwitch = () => {
+    useCodexStore.getState().resetChanges()
+    if (pendingSubView) {
+      setCodexSubView(pendingSubView)
+      setPendingSubView(null)
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-col gap-1 p-2">
+        {features.map(feature => (
+          <ActionButton
+            key={feature.id}
+            variant={codexSubView === feature.id ? 'secondary' : 'ghost'}
+            size="sm"
+            className={cn('justify-start w-full')}
+            onClick={() => handleSubViewChange(feature.id)}
+          >
+            <feature.icon className="h-4 w-4 mr-2" />
+            {t(feature.labelKey)}
+          </ActionButton>
+        ))}
+      </div>
+
+      <div className="mt-auto p-3 border-t text-xs text-muted-foreground">
+        {t('codex.features.hint')}
+      </div>
+
+      <AlertDialog
+        open={pendingSubView !== null}
+        onOpenChange={open => !open && setPendingSubView(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('sidebar.unsavedChanges.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('sidebar.unsavedChanges.description')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <ActionButton variant="destructive" onClick={handleDiscardAndSwitch}>
+              {t('sidebar.unsavedChanges.discard')}
+            </ActionButton>
+            <ActionButton onClick={handleSaveAndSwitch}>
+              {t('sidebar.unsavedChanges.save')}
+            </ActionButton>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src/components/codex/index.ts
+++ b/src/components/codex/index.ts
@@ -1,0 +1,3 @@
+export { CodexConfigPage } from './CodexConfigPage'
+export { CodexFeatureList } from './CodexFeatureList'
+

--- a/src/components/layout/LeftSideBar.tsx
+++ b/src/components/layout/LeftSideBar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Server, Bot, Terminal, ChevronDown, Check } from 'lucide-react'
+import { Server, Bot, Terminal, Code, ChevronDown, Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ActionButton } from '@/components/ui/action-button'
 import { ActionDropdownMenuItem } from '@/components/ui/action-dropdown-menu-item'
@@ -22,13 +22,15 @@ import {
 import { ChannelList, ChannelDialog } from '@/components/channels'
 import { DroidFeatureList } from '@/components/droid'
 import { OpenCodeFeatureList } from '@/components/opencode'
+import { CodexFeatureList } from '@/components/codex'
 import { useUIStore } from '@/store/ui-store'
 import { useChannelStore } from '@/store/channel-store'
 import { useModelStore } from '@/store/model-store'
 import { useOpenCodeStore } from '@/store/opencode-store'
+import { useCodexStore } from '@/store/codex-store'
 import { commands, type Channel } from '@/lib/bindings'
 
-type NavigationView = 'droid' | 'channels' | 'opencode'
+type NavigationView = 'droid' | 'channels' | 'opencode' | 'codex'
 
 interface LeftSideBarProps {
   children?: React.ReactNode
@@ -46,6 +48,7 @@ export function LeftSideBar({ children, className }: LeftSideBarProps) {
   const channelHasChanges = useChannelStore(state => state.hasChanges)
   const modelHasChanges = useModelStore(state => state.hasChanges)
   const opencodeHasChanges = useOpenCodeStore(state => state.hasChanges)
+  const codexHasChanges = useCodexStore(state => state.hasChanges)
 
   const [channelDialogOpen, setChannelDialogOpen] = useState(false)
   const [editingChannel, setEditingChannel] = useState<Channel | undefined>()
@@ -62,6 +65,11 @@ export function LeftSideBar({ children, className }: LeftSideBarProps) {
         <>
           <Terminal className="h-4 w-4 mr-2" />
           {t('sidebar.opencode')}
+        </>
+      ) : lastToolView === 'codex' ? (
+        <>
+          <Code className="h-4 w-4 mr-2" />
+          {t('sidebar.codex')}
         </>
       ) : (
         <>
@@ -80,7 +88,8 @@ export function LeftSideBar({ children, className }: LeftSideBarProps) {
     const hasUnsavedChanges =
       (currentView === 'droid' && modelHasChanges) ||
       (currentView === 'channels' && channelHasChanges) ||
-      (currentView === 'opencode' && opencodeHasChanges)
+      (currentView === 'opencode' && opencodeHasChanges) ||
+      (currentView === 'codex' && codexHasChanges)
 
     if (hasUnsavedChanges) {
       setPendingView(view)
@@ -96,6 +105,8 @@ export function LeftSideBar({ children, className }: LeftSideBarProps) {
       await useChannelStore.getState().saveChannels()
     } else if (currentView === 'opencode') {
       await useOpenCodeStore.getState().saveProfile()
+    } else if (currentView === 'codex') {
+      await useCodexStore.getState().saveProfile()
     }
     if (pendingView) {
       setCurrentView(pendingView)
@@ -110,6 +121,8 @@ export function LeftSideBar({ children, className }: LeftSideBarProps) {
       useChannelStore.getState().resetChanges()
     } else if (currentView === 'opencode') {
       useOpenCodeStore.getState().resetChanges()
+    } else if (currentView === 'codex') {
+      useCodexStore.getState().resetChanges()
     }
     if (pendingView) {
       setCurrentView(pendingView)
@@ -224,6 +237,18 @@ export function LeftSideBar({ children, className }: LeftSideBarProps) {
                   <Check className="h-4 w-4 ml-auto" />
                 )}
               </ActionDropdownMenuItem>
+              <ActionDropdownMenuItem
+                onClick={() => {
+                  handleViewChange('codex')
+                  setDropdownOpen(false)
+                }}
+              >
+                <Code className="h-4 w-4 mr-2" />
+                {t('sidebar.codex')}
+                {lastToolView === 'codex' && (
+                  <Check className="h-4 w-4 ml-auto" />
+                )}
+              </ActionDropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         )}
@@ -235,8 +260,10 @@ export function LeftSideBar({ children, className }: LeftSideBarProps) {
           <ChannelList onAddChannel={handleAddChannel} />
         ) : currentView === 'droid' ? (
           <DroidFeatureList />
-        ) : (
+        ) : currentView === 'opencode' ? (
           <OpenCodeFeatureList />
+        ) : (
+          <CodexFeatureList />
         )}
       </div>
 

--- a/src/components/layout/MainWindowContent.tsx
+++ b/src/components/layout/MainWindowContent.tsx
@@ -10,6 +10,7 @@ import {
   TerminalPage,
 } from '@/components/droid'
 import { OpenCodeConfigPage } from '@/components/opencode'
+import { CodexConfigPage } from '@/components/codex'
 import { ChannelDetail, ChannelDialog } from '@/components/channels'
 import { useUIStore } from '@/store/ui-store'
 import { useChannelStore } from '@/store/channel-store'
@@ -27,6 +28,7 @@ export function MainWindowContent({
   const { t } = useTranslation()
   const currentView = useUIStore(state => state.currentView)
   const droidSubView = useUIStore(state => state.droidSubView)
+  const codexSubView = useUIStore(state => state.codexSubView)
   const channels = useChannelStore(state => state.channels)
   const selectedChannelId = useChannelStore(state => state.selectedChannelId)
   const saveChannels = useChannelStore(state => state.saveChannels)
@@ -68,6 +70,16 @@ export function MainWindowContent({
       return <OpenCodeConfigPage />
     }
 
+    if (currentView === 'codex') {
+      return (
+        <>
+          {codexSubView === 'config' && <CodexConfigPage />}
+          {codexSubView === 'mcp' && <McpPage />}
+          {codexSubView === 'sessions' && <SessionsPage />}
+        </>
+      )
+    }
+
     // Channels view
     if (selectedChannel) {
       return (
@@ -98,7 +110,10 @@ export function MainWindowContent({
       {/* Terminal is always mounted across all views, hidden when not active */}
       <div
         className={cn(
-          !(currentView === 'droid' && droidSubView === 'terminal') && 'hidden',
+          !(
+            (currentView === 'droid' && droidSubView === 'terminal') ||
+            (currentView === 'codex' && codexSubView === 'terminal')
+          ) && 'hidden',
           'absolute inset-0'
         )}
       >

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -582,6 +582,116 @@ async toggleMcpServer(name: string, disabled: boolean) : Promise<Result<null, st
 }
 },
 /**
+ * 列出所有 Codex Profiles
+ */
+async listCodexProfiles() : Promise<Result<CodexProfile[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_codex_profiles") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 获取指定 Codex Profile
+ */
+async getCodexProfile(id: string) : Promise<Result<CodexProfile, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_codex_profile", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 保存 Codex Profile
+ */
+async saveCodexProfile(profile: CodexProfile) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("save_codex_profile", { profile }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 删除 Codex Profile
+ */
+async deleteCodexProfile(id: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("delete_codex_profile", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 复制 Codex Profile
+ */
+async duplicateCodexProfile(id: string, newName: string) : Promise<Result<CodexProfile, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("duplicate_codex_profile", { id, newName }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 创建默认 Codex Profile
+ */
+async createDefaultCodexProfile() : Promise<Result<CodexProfile, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_default_codex_profile") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 获取当前生效的 Codex Profile ID
+ */
+async getActiveCodexProfileId() : Promise<Result<string | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_active_codex_profile_id") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 应用 Codex Profile（写入 ~/.codex/*）
+ */
+async applyCodexProfile(id: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("apply_codex_profile", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 获取 Codex Live 配置状态
+ */
+async getCodexConfigStatus() : Promise<Result<CodexConfigStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_codex_config_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 读取当前 ~/.codex/* 配置
+ */
+async readCodexCurrentConfig() : Promise<Result<CodexCurrentConfig, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("read_codex_current_config") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * List all profiles
  */
 async listOpencodeProfiles() : Promise<Result<OpenCodeProfile[], string>> {
@@ -997,6 +1107,18 @@ export type McpServerType = "stdio" | "http"
  * Model info returned from API
  */
 export type ModelInfo = { id: string; name: string | null }
+/**
+ * Codex Live 配置状态
+ */
+export type CodexConfigStatus = { authExists: boolean; configExists: boolean; authPath: string; configPath: string }
+/**
+ * 当前 Codex Live 配置（从 ~/.codex/* 读取）
+ */
+export type CodexCurrentConfig = { auth: Partial<{ [key in string]: JsonValue }>; configToml: string }
+/**
+ * Codex Profile
+ */
+export type CodexProfile = { id: string; name: string; description?: string | null; createdAt: string; updatedAt: string; auth: Partial<{ [key in string]: JsonValue }>; configToml: string }
 /**
  * Configuration status
  */

--- a/src/store/codex-store.ts
+++ b/src/store/codex-store.ts
@@ -1,0 +1,261 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import {
+  commands,
+  type CodexProfile,
+  type CodexConfigStatus,
+  type CodexCurrentConfig,
+  type JsonValue,
+} from '@/lib/bindings'
+
+interface CodexState {
+  profiles: CodexProfile[]
+  activeProfileId: string | null
+  currentProfile: CodexProfile | null
+  originalProfile: CodexProfile | null
+  hasChanges: boolean
+  isLoading: boolean
+  error: string | null
+  configStatus: CodexConfigStatus | null
+
+  loadProfiles: () => Promise<void>
+  loadActiveProfileId: () => Promise<void>
+  loadConfigStatus: () => Promise<void>
+  selectProfile: (id: string) => void
+  createProfile: (name: string) => Promise<void>
+  saveProfile: () => Promise<void>
+  deleteProfile: (id: string) => Promise<void>
+  duplicateProfile: (id: string, newName: string) => Promise<void>
+  applyProfile: (id: string) => Promise<void>
+  loadFromLiveConfig: () => Promise<void>
+  updateProfileName: (name: string) => void
+  updateProfileDescription: (description: string) => void
+  updateAuthValue: (key: string, value: JsonValue) => void
+  updateConfigToml: (toml: string) => void
+  resetChanges: () => void
+  setError: (error: string | null) => void
+}
+
+function profilesEqual(a: CodexProfile | null, b: CodexProfile | null): boolean {
+  if (!a || !b) return a === b
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+export const useCodexStore = create<CodexState>()(
+  devtools(
+    (set, get) => ({
+      profiles: [],
+      activeProfileId: null,
+      currentProfile: null,
+      originalProfile: null,
+      hasChanges: false,
+      isLoading: false,
+      error: null,
+      configStatus: null,
+
+      loadProfiles: async () => {
+        set({ isLoading: true, error: null }, undefined, 'codex/loadProfiles/start')
+        try {
+          const result = await commands.listCodexProfiles()
+          if (result.status === 'ok') {
+            let profiles = result.data
+            if (profiles.length === 0) {
+              const created = await commands.createDefaultCodexProfile()
+              if (created.status === 'ok') {
+                profiles = [created.data]
+              }
+            }
+            set({ profiles, isLoading: false }, undefined, 'codex/loadProfiles/success')
+          } else {
+            set({ error: result.error, isLoading: false }, undefined, 'codex/loadProfiles/error')
+          }
+        } catch (e) {
+          set({ error: String(e), isLoading: false }, undefined, 'codex/loadProfiles/exception')
+        }
+      },
+
+      loadActiveProfileId: async () => {
+        try {
+          const result = await commands.getActiveCodexProfileId()
+          if (result.status === 'ok') {
+            set({ activeProfileId: result.data }, undefined, 'codex/loadActiveProfileId')
+            if (result.data) get().selectProfile(result.data)
+          }
+        } catch {
+          // ignore
+        }
+      },
+
+      loadConfigStatus: async () => {
+        try {
+          const result = await commands.getCodexConfigStatus()
+          if (result.status === 'ok') {
+            set({ configStatus: result.data }, undefined, 'codex/loadConfigStatus')
+          }
+        } catch {
+          // ignore
+        }
+      },
+
+      selectProfile: id => {
+        const profile = get().profiles.find(p => p.id === id) || null
+        set(
+          {
+            currentProfile: profile ? JSON.parse(JSON.stringify(profile)) : null,
+            originalProfile: profile ? JSON.parse(JSON.stringify(profile)) : null,
+            hasChanges: false,
+          },
+          undefined,
+          'codex/selectProfile'
+        )
+      },
+
+      createProfile: async name => {
+        const now = new Date().toISOString()
+        const profile: CodexProfile = {
+          id: '',
+          name,
+          description: '',
+          createdAt: now,
+          updatedAt: now,
+          auth: { OPENAI_API_KEY: '' } as Record<string, JsonValue>,
+          configToml: '',
+        }
+        const result = await commands.saveCodexProfile(profile)
+        if (result.status !== 'ok') throw new Error(result.error)
+        await get().loadProfiles()
+      },
+
+      saveProfile: async () => {
+        const { currentProfile } = get()
+        if (!currentProfile) return
+        const result = await commands.saveCodexProfile(currentProfile)
+        if (result.status !== 'ok') {
+          set({ error: result.error }, undefined, 'codex/saveProfile/error')
+          return
+        }
+        await get().loadProfiles()
+        get().selectProfile(currentProfile.id)
+      },
+
+      deleteProfile: async id => {
+        const result = await commands.deleteCodexProfile(id)
+        if (result.status !== 'ok') {
+          set({ error: result.error }, undefined, 'codex/deleteProfile/error')
+          return
+        }
+        await get().loadProfiles()
+        const next = get().profiles[0]?.id || null
+        if (next) get().selectProfile(next)
+      },
+
+      duplicateProfile: async (id, newName) => {
+        const result = await commands.duplicateCodexProfile(id, newName)
+        if (result.status !== 'ok') {
+          set({ error: result.error }, undefined, 'codex/duplicateProfile/error')
+          return
+        }
+        await get().loadProfiles()
+        get().selectProfile(result.data.id)
+      },
+
+      applyProfile: async id => {
+        const result = await commands.applyCodexProfile(id)
+        if (result.status !== 'ok') {
+          set({ error: result.error }, undefined, 'codex/applyProfile/error')
+          return
+        }
+        set({ activeProfileId: id }, undefined, 'codex/applyProfile/success')
+        await get().loadConfigStatus()
+      },
+
+      loadFromLiveConfig: async () => {
+        const { currentProfile } = get()
+        if (!currentProfile) return
+        const result = await commands.readCodexCurrentConfig()
+        if (result.status !== 'ok') {
+          set({ error: result.error }, undefined, 'codex/loadFromLiveConfig/error')
+          return
+        }
+        const live: CodexCurrentConfig = result.data
+        const updated: CodexProfile = {
+          ...currentProfile,
+          auth: live.auth as Record<string, JsonValue>,
+          configToml: live.configToml,
+          updatedAt: new Date().toISOString(),
+        }
+        set(
+          {
+            currentProfile: updated,
+            hasChanges: !profilesEqual(updated, get().originalProfile),
+          },
+          undefined,
+          'codex/loadFromLiveConfig/success'
+        )
+      },
+
+      updateProfileName: name => {
+        const { currentProfile } = get()
+        if (!currentProfile) return
+        const updated = { ...currentProfile, name, updatedAt: new Date().toISOString() }
+        set(
+          { currentProfile: updated, hasChanges: !profilesEqual(updated, get().originalProfile) },
+          undefined,
+          'codex/updateProfileName'
+        )
+      },
+
+      updateProfileDescription: description => {
+        const { currentProfile } = get()
+        if (!currentProfile) return
+        const updated = { ...currentProfile, description, updatedAt: new Date().toISOString() }
+        set(
+          { currentProfile: updated, hasChanges: !profilesEqual(updated, get().originalProfile) },
+          undefined,
+          'codex/updateProfileDescription'
+        )
+      },
+
+      updateAuthValue: (key, value) => {
+        const { currentProfile } = get()
+        if (!currentProfile) return
+        const auth = { ...(currentProfile.auth as Record<string, JsonValue>) }
+        auth[key] = value
+        const updated = { ...currentProfile, auth, updatedAt: new Date().toISOString() }
+        set(
+          { currentProfile: updated, hasChanges: !profilesEqual(updated, get().originalProfile) },
+          undefined,
+          'codex/updateAuthValue'
+        )
+      },
+
+      updateConfigToml: toml => {
+        const { currentProfile } = get()
+        if (!currentProfile) return
+        const updated = { ...currentProfile, configToml: toml, updatedAt: new Date().toISOString() }
+        set(
+          { currentProfile: updated, hasChanges: !profilesEqual(updated, get().originalProfile) },
+          undefined,
+          'codex/updateConfigToml'
+        )
+      },
+
+      resetChanges: () => {
+        const { originalProfile } = get()
+        set(
+          {
+            currentProfile: originalProfile ? JSON.parse(JSON.stringify(originalProfile)) : null,
+            hasChanges: false,
+            error: null,
+          },
+          undefined,
+          'codex/resetChanges'
+        )
+      },
+
+      setError: error => set({ error }, undefined, 'codex/setError'),
+    }),
+    { name: 'codex-store' }
+  )
+)
+

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
-type NavigationView = 'droid' | 'channels' | 'opencode'
-type ToolView = 'droid' | 'opencode'
+type NavigationView = 'droid' | 'channels' | 'opencode' | 'codex'
+type ToolView = 'droid' | 'opencode' | 'codex'
 export type DroidSubView =
   | 'models'
   | 'helpers'
@@ -11,6 +11,7 @@ export type DroidSubView =
   | 'sessions'
   | 'terminal'
 export type OpenCodeSubView = 'providers'
+export type CodexSubView = 'config' | 'mcp' | 'sessions' | 'terminal'
 
 export interface PendingUpdate {
   version: string
@@ -26,6 +27,7 @@ interface UIState {
   lastToolView: ToolView
   droidSubView: DroidSubView
   opencodeSubView: OpenCodeSubView
+  codexSubView: CodexSubView
   lastSpecExportPath: string | null
   pendingUpdate: PendingUpdate | null
 
@@ -40,6 +42,7 @@ interface UIState {
   setCurrentView: (view: NavigationView) => void
   setDroidSubView: (view: DroidSubView) => void
   setOpenCodeSubView: (view: OpenCodeSubView) => void
+  setCodexSubView: (view: CodexSubView) => void
   setLastSpecExportPath: (path: string) => void
   setPendingUpdate: (update: PendingUpdate | null) => void
   clearPendingUpdate: () => void
@@ -57,6 +60,7 @@ export const useUIStore = create<UIState>()(
         lastToolView: 'droid',
         droidSubView: 'models',
         opencodeSubView: 'providers',
+        codexSubView: 'config',
         lastSpecExportPath: null,
         pendingUpdate: null,
 
@@ -112,9 +116,9 @@ export const useUIStore = create<UIState>()(
           set(
             state => ({
               currentView: view,
-              // Update lastToolView when switching to droid/opencode
+              // Update lastToolView when switching tools
               lastToolView:
-                view === 'droid' || view === 'opencode'
+                view === 'droid' || view === 'opencode' || view === 'codex'
                   ? view
                   : state.lastToolView,
             }),
@@ -127,6 +131,9 @@ export const useUIStore = create<UIState>()(
 
         setOpenCodeSubView: view =>
           set({ opencodeSubView: view }, undefined, 'setOpenCodeSubView'),
+
+        setCodexSubView: view =>
+          set({ codexSubView: view }, undefined, 'setCodexSubView'),
 
         setLastSpecExportPath: path =>
           set({ lastSpecExportPath: path }, undefined, 'setLastSpecExportPath'),
@@ -143,6 +150,7 @@ export const useUIStore = create<UIState>()(
           lastSpecExportPath: state.lastSpecExportPath,
           currentView: state.currentView,
           lastToolView: state.lastToolView,
+          codexSubView: state.codexSubView,
           leftSidebarVisible: state.leftSidebarVisible,
           rightSidebarVisible: state.rightSidebarVisible,
         }),


### PR DESCRIPTION
@本 PR 将 cc-switch 的 Codex 配置能力以 DroidGear 一致方式移植进来：

- 新增 Codex CLI 配置管理（Profile + 读写 ~/.codex/auth.json 与 ~/.codex/config.toml，含 TOML 校验与原子写）
- Codex 页面参考 Droid：提供 配置 / MCP 服务器 / 会话 / 终端 子页（MCP/会话/终端复用现有管理页）
- 移除 Codex 预设模板相关 UI 与残留文案

验证：npm run typecheck / lint / test:run 通过；tauri build (x86_64-pc-windows-gnu, --no-bundle) 通过。

备注：helloagents/ 为本地开发配置，不纳入仓库与 PR。
@