### PR TITLE
不要在错误的地方触发保存profile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Auto-detect text files and normalize line endings to LF
+* text=auto
+
+# Rust / Cargo files - force LF
+*.rs text eol=lf
+Cargo.toml text eol=lf
+Cargo.lock text eol=lf
+
+# JavaScript / TypeScript / npm files - force LF
+*.js text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.html text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.env text eol=lf
+
+# Binary files - keep as-is
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.icns binary
+*.ico binary

--- a/src/store/openclaw-store.ts
+++ b/src/store/openclaw-store.ts
@@ -239,8 +239,6 @@ export const useOpenClawStore = create<OpenClawState>()(
           undefined,
           'openclaw/loadFromLiveConfig/success'
         )
-        // Auto-save after loading from live config
-        await get().saveProfile()
       },
 
       updateProfileName: async name => {


### PR DESCRIPTION
* fix: prevent loadFromLiveConfig from auto-saving and overwriting profile

总结一下修正后的完整流程：
1. 配置 provider → 保存 → 写入 ~/.droidgear/openclaw/profiles/{id}.json
2. 点"应用" → 写入 ~/.openclaw/openclaw.json
3. 点"读取" → 从 ~/.openclaw/openclaw.json 读到 UI 预览，不再自动保存，不会覆盖第 1 步的修改