### PR TITLE
[droid] launch Droid from a temporary settings snapshot

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -455,6 +455,7 @@
   "droid.settingsFile.deleteConfirm": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone.",
   "droid.settingsFile.launch": "Launch Droid",
   "droid.settingsFile.launchTooltip": "Open Droid CLI in a new terminal window",
+  "droid.settingsFile.launchSaveFailed": "Could not launch Droid because model changes could not be saved",
 
   "common.rename": "Rename",
   "common.export": "Export",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -455,6 +455,7 @@
   "droid.settingsFile.deleteConfirm": "确定要删除 \"{{name}}\" 吗？此操作无法撤销。",
   "droid.settingsFile.launch": "启动 Droid",
   "droid.settingsFile.launchTooltip": "在新终端窗口中打开 Droid CLI",
+  "droid.settingsFile.launchSaveFailed": "无法启动 Droid，因为模型更改未能保存",
 
   "common.rename": "重命名",
   "common.export": "导出",

--- a/src-tauri/crates/droidgear-core/src/droid_runtime.rs
+++ b/src-tauri/crates/droidgear-core/src/droid_runtime.rs
@@ -1,0 +1,245 @@
+//! Droid temporary run planning.
+//!
+//! Builds a temporary settings file plus runtime env policy without mutating
+//! the live Factory settings file.
+
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use crate::{droid_settings_files, storage};
+
+const DROID_RUNTIME_DIR: &str = "runtime/droid";
+const TEMP_SETTINGS_PREFIX: &str = "temporary-run-";
+const TEMP_SETTINGS_EXTENSION: &str = "json";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DroidTemporaryRunPlan {
+    pub program: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub unset_env: Vec<String>,
+    pub temp_settings_path: PathBuf,
+}
+
+fn runtime_dir_for_home(home_dir: &Path) -> PathBuf {
+    crate::paths::droidgear_dir_from_home(home_dir).join(DROID_RUNTIME_DIR)
+}
+
+fn next_temp_settings_path(home_dir: &Path) -> Result<PathBuf, String> {
+    let runtime_dir = runtime_dir_for_home(home_dir);
+    if !runtime_dir.exists() {
+        std::fs::create_dir_all(&runtime_dir)
+            .map_err(|e| format!("Failed to create Droid runtime directory: {e}"))?;
+    }
+
+    let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ");
+    Ok(runtime_dir.join(format!(
+        "{TEMP_SETTINGS_PREFIX}{timestamp}-{}.{}",
+        Uuid::new_v4(),
+        TEMP_SETTINGS_EXTENSION
+    )))
+}
+
+fn copy_active_settings_to_temp(home_dir: &Path, destination: &Path) -> Result<(), String> {
+    let source = droid_settings_files::get_active_settings_path_for_home(home_dir)?;
+
+    if source.exists() {
+        let contents = std::fs::read(&source)
+            .map_err(|e| format!("Failed to read active Droid settings: {e}"))?;
+        storage::atomic_write(destination, &contents)?;
+    } else {
+        storage::atomic_write(destination, b"{}")?;
+    }
+
+    Ok(())
+}
+
+fn build_env_overrides() -> (Vec<(String, String)>, Vec<String>) {
+    (
+        vec![(
+            "FACTORY_DROID_AUTO_UPDATE_ENABLED".to_string(),
+            "0".to_string(),
+        )],
+        vec!["ANTHROPIC_AUTH_TOKEN".to_string()],
+    )
+}
+
+pub fn cleanup_stale_temp_settings_for_home(home_dir: &Path) -> Result<u32, String> {
+    let runtime_dir = runtime_dir_for_home(home_dir);
+    if !runtime_dir.exists() {
+        return Ok(0);
+    }
+
+    let cutoff = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(60 * 60 * 24))
+        .ok_or_else(|| "Failed to compute Droid runtime cleanup cutoff".to_string())?;
+
+    let mut removed = 0;
+
+    let entries = std::fs::read_dir(&runtime_dir)
+        .map_err(|e| format!("Failed to read Droid runtime directory: {e}"))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+
+        if !name.starts_with(TEMP_SETTINGS_PREFIX) {
+            continue;
+        }
+
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+
+        if modified >= cutoff {
+            continue;
+        }
+
+        if std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+        }
+    }
+
+    Ok(removed)
+}
+
+pub fn build_temporary_run_plan_for_home(home_dir: &Path) -> Result<DroidTemporaryRunPlan, String> {
+    let temp_settings_path = next_temp_settings_path(home_dir)?;
+    copy_active_settings_to_temp(home_dir, &temp_settings_path)?;
+
+    let (env, unset_env) = build_env_overrides();
+
+    Ok(DroidTemporaryRunPlan {
+        program: "droid".to_string(),
+        args: vec![
+            "--settings".to_string(),
+            temp_settings_path.to_string_lossy().to_string(),
+        ],
+        env,
+        unset_env,
+        temp_settings_path,
+    })
+}
+
+pub fn build_temporary_run_plan() -> Result<DroidTemporaryRunPlan, String> {
+    let home_dir = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
+    build_temporary_run_plan_for_home(&home_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::{build_temporary_run_plan_for_home, cleanup_stale_temp_settings_for_home};
+    use crate::droid_settings_files;
+
+    fn home(temp: &TempDir) -> &Path {
+        temp.path()
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn temporary_run_plan_copies_global_settings_and_applies_default_env_policy() {
+        let temp = TempDir::new().unwrap();
+        let global_path = home(&temp).join(".factory/settings.json");
+        write_file(&global_path, r#"{"customModels":[{"id":"demo"}]}"#);
+
+        let plan = build_temporary_run_plan_for_home(home(&temp)).unwrap();
+
+        assert_eq!(plan.program, "droid");
+        assert_eq!(plan.args[0], "--settings");
+        assert_eq!(plan.args[1], plan.temp_settings_path.to_string_lossy());
+        assert_eq!(
+            std::fs::read_to_string(&plan.temp_settings_path).unwrap(),
+            r#"{"customModels":[{"id":"demo"}]}"#
+        );
+        assert_eq!(
+            plan.env,
+            vec![(
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED".to_string(),
+                "0".to_string()
+            )]
+        );
+        assert_eq!(plan.unset_env, vec!["ANTHROPIC_AUTH_TOKEN".to_string()]);
+    }
+
+    #[test]
+    fn temporary_run_plan_uses_active_custom_settings_file_as_base() {
+        let temp = TempDir::new().unwrap();
+        let active_settings_path = home(&temp).join(".droidgear/droid-settings/profile-a.json");
+        write_file(
+            &active_settings_path,
+            r#"{"sessionDefaultSettings":{"model":"x"}}"#,
+        );
+
+        droid_settings_files::set_active_settings_file_for_home(
+            home(&temp),
+            Some("profile-a".to_string()),
+        )
+        .unwrap();
+
+        let plan = build_temporary_run_plan_for_home(home(&temp)).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&plan.temp_settings_path).unwrap(),
+            r#"{"sessionDefaultSettings":{"model":"x"}}"#
+        );
+    }
+
+    #[test]
+    fn temporary_run_plan_creates_empty_settings_when_base_file_is_missing() {
+        let temp = TempDir::new().unwrap();
+
+        let plan = build_temporary_run_plan_for_home(home(&temp)).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&plan.temp_settings_path).unwrap(),
+            "{}"
+        );
+    }
+
+    #[test]
+    fn cleanup_stale_temp_settings_only_removes_old_runtime_files() {
+        let temp = TempDir::new().unwrap();
+        let runtime_dir = home(&temp).join(".droidgear/runtime/droid");
+        std::fs::create_dir_all(&runtime_dir).unwrap();
+
+        let fresh_path = runtime_dir.join("temporary-run-fresh.json");
+        let stale_path = runtime_dir.join("temporary-run-stale.json");
+        let other_path = runtime_dir.join("notes.txt");
+        write_file(&fresh_path, "{}");
+        write_file(&stale_path, "{}");
+        write_file(&other_path, "{}");
+
+        let stale_time = filetime::FileTime::from_unix_time(
+            (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64)
+                - 60 * 60 * 48,
+            0,
+        );
+        filetime::set_file_mtime(&stale_path, stale_time).unwrap();
+
+        let removed = cleanup_stale_temp_settings_for_home(home(&temp)).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(fresh_path.exists());
+        assert!(!stale_path.exists());
+        assert!(other_path.exists());
+    }
+}

--- a/src-tauri/crates/droidgear-core/src/droid_runtime.rs
+++ b/src-tauri/crates/droidgear-core/src/droid_runtime.rs
@@ -3,8 +3,9 @@
 //! Builds a temporary settings file plus runtime env policy without mutating
 //! the live Factory settings file.
 
+use serde::{Deserialize, Serialize};
+use specta::Type;
 use std::path::{Path, PathBuf};
-
 use uuid::Uuid;
 
 use crate::{droid_settings_files, storage};
@@ -12,6 +13,15 @@ use crate::{droid_settings_files, storage};
 const DROID_RUNTIME_DIR: &str = "runtime/droid";
 const TEMP_SETTINGS_PREFIX: &str = "temporary-run-";
 const TEMP_SETTINGS_EXTENSION: &str = "json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DroidRunPreferences {
+    #[serde(default)]
+    pub disable_auto_update_env: Option<bool>,
+    #[serde(default)]
+    pub unset_anthropic_auth_token: Option<bool>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DroidTemporaryRunPlan {
@@ -41,12 +51,10 @@ fn next_temp_settings_path(home_dir: &Path) -> Result<PathBuf, String> {
     )))
 }
 
-fn copy_active_settings_to_temp(home_dir: &Path, destination: &Path) -> Result<(), String> {
-    let source = droid_settings_files::get_active_settings_path_for_home(home_dir)?;
-
+fn copy_settings_to_temp(source: &Path, destination: &Path) -> Result<(), String> {
     if source.exists() {
-        let contents = std::fs::read(&source)
-            .map_err(|e| format!("Failed to read active Droid settings: {e}"))?;
+        let contents = std::fs::read(source)
+            .map_err(|e| format!("Failed to read Droid settings file: {e}"))?;
         storage::atomic_write(destination, &contents)?;
     } else {
         storage::atomic_write(destination, b"{}")?;
@@ -55,14 +63,30 @@ fn copy_active_settings_to_temp(home_dir: &Path, destination: &Path) -> Result<(
     Ok(())
 }
 
-fn build_env_overrides() -> (Vec<(String, String)>, Vec<String>) {
-    (
-        vec![(
+fn should_disable_auto_update_env(prefs: &DroidRunPreferences) -> bool {
+    prefs.disable_auto_update_env.unwrap_or(true)
+}
+
+fn should_unset_anthropic_auth_token(prefs: &DroidRunPreferences) -> bool {
+    prefs.unset_anthropic_auth_token.unwrap_or(true)
+}
+
+fn build_env_overrides(prefs: &DroidRunPreferences) -> (Vec<(String, String)>, Vec<String>) {
+    let mut env = Vec::new();
+    let mut unset_env = Vec::new();
+
+    if should_disable_auto_update_env(prefs) {
+        env.push((
             "FACTORY_DROID_AUTO_UPDATE_ENABLED".to_string(),
             "0".to_string(),
-        )],
-        vec!["ANTHROPIC_AUTH_TOKEN".to_string()],
-    )
+        ));
+    }
+
+    if should_unset_anthropic_auth_token(prefs) {
+        unset_env.push("ANTHROPIC_AUTH_TOKEN".to_string());
+    }
+
+    (env, unset_env)
 }
 
 pub fn cleanup_stale_temp_settings_for_home(home_dir: &Path) -> Result<u32, String> {
@@ -109,11 +133,15 @@ pub fn cleanup_stale_temp_settings_for_home(home_dir: &Path) -> Result<u32, Stri
     Ok(removed)
 }
 
-pub fn build_temporary_run_plan_for_home(home_dir: &Path) -> Result<DroidTemporaryRunPlan, String> {
+pub fn build_temporary_run_plan_for_home(
+    home_dir: &Path,
+    prefs: &DroidRunPreferences,
+) -> Result<DroidTemporaryRunPlan, String> {
     let temp_settings_path = next_temp_settings_path(home_dir)?;
-    copy_active_settings_to_temp(home_dir, &temp_settings_path)?;
+    let source = droid_settings_files::get_active_settings_path_for_home(home_dir)?;
+    copy_settings_to_temp(&source, &temp_settings_path)?;
 
-    let (env, unset_env) = build_env_overrides();
+    let (env, unset_env) = build_env_overrides(prefs);
 
     Ok(DroidTemporaryRunPlan {
         program: "droid".to_string(),
@@ -127,19 +155,44 @@ pub fn build_temporary_run_plan_for_home(home_dir: &Path) -> Result<DroidTempora
     })
 }
 
-pub fn build_temporary_run_plan() -> Result<DroidTemporaryRunPlan, String> {
+pub fn build_temporary_run_plan_from_settings_path_for_home(
+    home_dir: &Path,
+    settings_path: &Path,
+    prefs: &DroidRunPreferences,
+) -> Result<DroidTemporaryRunPlan, String> {
+    let temp_settings_path = next_temp_settings_path(home_dir)?;
+    copy_settings_to_temp(settings_path, &temp_settings_path)?;
+
+    let (env, unset_env) = build_env_overrides(prefs);
+
+    Ok(DroidTemporaryRunPlan {
+        program: "droid".to_string(),
+        args: vec![
+            "--settings".to_string(),
+            temp_settings_path.to_string_lossy().to_string(),
+        ],
+        env,
+        unset_env,
+        temp_settings_path,
+    })
+}
+
+pub fn build_temporary_run_plan(
+    prefs: &DroidRunPreferences,
+) -> Result<DroidTemporaryRunPlan, String> {
     let home_dir = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
-    build_temporary_run_plan_for_home(&home_dir)
+    build_temporary_run_plan_for_home(&home_dir, prefs)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
-    use tempfile::TempDir;
-
-    use super::{build_temporary_run_plan_for_home, cleanup_stale_temp_settings_for_home};
+    use super::{
+        build_temporary_run_plan_for_home, build_temporary_run_plan_from_settings_path_for_home,
+        cleanup_stale_temp_settings_for_home, DroidRunPreferences,
+    };
     use crate::droid_settings_files;
+    use std::path::Path;
+    use tempfile::TempDir;
 
     fn home(temp: &TempDir) -> &Path {
         temp.path()
@@ -158,7 +211,8 @@ mod tests {
         let global_path = home(&temp).join(".factory/settings.json");
         write_file(&global_path, r#"{"customModels":[{"id":"demo"}]}"#);
 
-        let plan = build_temporary_run_plan_for_home(home(&temp)).unwrap();
+        let plan = build_temporary_run_plan_for_home(home(&temp), &DroidRunPreferences::default())
+            .unwrap();
 
         assert_eq!(plan.program, "droid");
         assert_eq!(plan.args[0], "--settings");
@@ -192,7 +246,8 @@ mod tests {
         )
         .unwrap();
 
-        let plan = build_temporary_run_plan_for_home(home(&temp)).unwrap();
+        let plan = build_temporary_run_plan_for_home(home(&temp), &DroidRunPreferences::default())
+            .unwrap();
 
         assert_eq!(
             std::fs::read_to_string(&plan.temp_settings_path).unwrap(),
@@ -201,10 +256,52 @@ mod tests {
     }
 
     #[test]
+    fn temporary_run_plan_can_use_an_explicit_settings_path_without_switching_active_file() {
+        let temp = TempDir::new().unwrap();
+        let explicit_settings_path = home(&temp).join(".droidgear/droid-settings/profile-b.json");
+        write_file(
+            &explicit_settings_path,
+            r#"{"sessionDefaultSettings":{"model":"y"}}"#,
+        );
+
+        let plan = build_temporary_run_plan_from_settings_path_for_home(
+            home(&temp),
+            &explicit_settings_path,
+            &DroidRunPreferences::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&plan.temp_settings_path).unwrap(),
+            r#"{"sessionDefaultSettings":{"model":"y"}}"#
+        );
+    }
+
+    #[test]
+    fn temporary_run_plan_respects_explicit_run_policy_overrides() {
+        let temp = TempDir::new().unwrap();
+        let global_path = home(&temp).join(".factory/settings.json");
+        write_file(&global_path, "{}");
+
+        let plan = build_temporary_run_plan_for_home(
+            home(&temp),
+            &DroidRunPreferences {
+                disable_auto_update_env: Some(false),
+                unset_anthropic_auth_token: Some(false),
+            },
+        )
+        .unwrap();
+
+        assert!(plan.env.is_empty());
+        assert!(plan.unset_env.is_empty());
+    }
+
+    #[test]
     fn temporary_run_plan_creates_empty_settings_when_base_file_is_missing() {
         let temp = TempDir::new().unwrap();
 
-        let plan = build_temporary_run_plan_for_home(home(&temp)).unwrap();
+        let plan = build_temporary_run_plan_for_home(home(&temp), &DroidRunPreferences::default())
+            .unwrap();
 
         assert_eq!(
             std::fs::read_to_string(&plan.temp_settings_path).unwrap(),
@@ -218,28 +315,22 @@ mod tests {
         let runtime_dir = home(&temp).join(".droidgear/runtime/droid");
         std::fs::create_dir_all(&runtime_dir).unwrap();
 
-        let fresh_path = runtime_dir.join("temporary-run-fresh.json");
-        let stale_path = runtime_dir.join("temporary-run-stale.json");
-        let other_path = runtime_dir.join("notes.txt");
-        write_file(&fresh_path, "{}");
-        write_file(&stale_path, "{}");
-        write_file(&other_path, "{}");
+        let stale_file = runtime_dir.join("temporary-run-20000101T000000.000Z.json");
+        let fresh_file = runtime_dir.join("temporary-run-keep.json");
+        let other_file = runtime_dir.join("notes.txt");
 
-        let stale_time = filetime::FileTime::from_unix_time(
-            (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64)
-                - 60 * 60 * 48,
-            0,
-        );
-        filetime::set_file_mtime(&stale_path, stale_time).unwrap();
+        write_file(&stale_file, "{}");
+        write_file(&fresh_file, "{}");
+        write_file(&other_file, "{}");
+
+        let stale_time = filetime::FileTime::from_unix_time(0, 0);
+        filetime::set_file_mtime(&stale_file, stale_time).unwrap();
 
         let removed = cleanup_stale_temp_settings_for_home(home(&temp)).unwrap();
 
         assert_eq!(removed, 1);
-        assert!(fresh_path.exists());
-        assert!(!stale_path.exists());
-        assert!(other_path.exists());
+        assert!(!stale_file.exists());
+        assert!(fresh_file.exists());
+        assert!(other_file.exists());
     }
 }

--- a/src-tauri/crates/droidgear-core/src/droid_settings_files.rs
+++ b/src-tauri/crates/droidgear-core/src/droid_settings_files.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::paths;
 
@@ -40,43 +40,62 @@ fn system_home_dir() -> Result<PathBuf, String> {
     dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())
 }
 
+fn droidgear_dir_for_home(home_dir: &Path) -> PathBuf {
+    paths::droidgear_dir_from_home(home_dir)
+}
+
 fn droidgear_dir() -> Result<PathBuf, String> {
     Ok(paths::droidgear_dir_from_home(&system_home_dir()?))
+}
+
+fn droid_settings_dir_for_home(home_dir: &Path) -> PathBuf {
+    droidgear_dir_for_home(home_dir).join(DROID_SETTINGS_DIR)
 }
 
 fn droid_settings_dir() -> Result<PathBuf, String> {
     Ok(droidgear_dir()?.join(DROID_SETTINGS_DIR))
 }
 
+fn global_settings_path_for_home(home_dir: &Path) -> PathBuf {
+    home_dir.join(".factory").join("settings.json")
+}
+
 fn global_settings_path() -> Result<PathBuf, String> {
     let home = system_home_dir()?;
-    Ok(home.join(".factory").join("settings.json"))
+    Ok(global_settings_path_for_home(&home))
+}
+
+/// Resolves the absolute path to the currently active settings file.
+/// Returns the global path if no custom file is set, or if the active file doesn't exist.
+pub(crate) fn get_active_settings_path_for_home(home_dir: &Path) -> Result<PathBuf, String> {
+    let active_name = load_active_file_name_for_home(home_dir)?;
+    match active_name {
+        Some(name) if !name.is_empty() => {
+            let custom_path = droid_settings_dir_for_home(home_dir)
+                .join(&name)
+                .with_extension("json");
+            if custom_path.exists() {
+                Ok(custom_path)
+            } else {
+                Ok(global_settings_path_for_home(home_dir))
+            }
+        }
+        _ => Ok(global_settings_path_for_home(home_dir)),
+    }
 }
 
 /// Resolves the absolute path to the currently active settings file.
 /// Returns the global path if no custom file is set, or if the active file doesn't exist.
 pub fn get_active_settings_path() -> Result<PathBuf, String> {
-    let active_name = load_active_file_name()?;
-    match active_name {
-        Some(name) if !name.is_empty() => {
-            let custom_path = droid_settings_dir()?.join(&name).with_extension("json");
-            if custom_path.exists() {
-                Ok(custom_path)
-            } else {
-                // Fall back to global if custom file doesn't exist
-                global_settings_path()
-            }
-        }
-        _ => global_settings_path(),
-    }
+    get_active_settings_path_for_home(&system_home_dir()?)
 }
 
 // ============================================================================
 // Active file tracking
 // ============================================================================
 
-fn load_active_file_name() -> Result<Option<String>, String> {
-    let settings_path = paths::get_droidgear_settings_path()?;
+fn load_active_file_name_for_home(home_dir: &Path) -> Result<Option<String>, String> {
+    let settings_path = paths::get_droidgear_settings_path_for_home(home_dir);
     let settings = paths::read_droidgear_settings_from_path_internal(&settings_path)?;
     Ok(settings
         .get(ACTIVE_FILE_KEY)
@@ -84,8 +103,12 @@ fn load_active_file_name() -> Result<Option<String>, String> {
         .map(String::from))
 }
 
-fn save_active_file_name(name: Option<&str>) -> Result<(), String> {
-    let settings_path = paths::get_droidgear_settings_path()?;
+fn load_active_file_name() -> Result<Option<String>, String> {
+    load_active_file_name_for_home(&system_home_dir()?)
+}
+
+fn save_active_file_name_for_home(home_dir: &Path, name: Option<&str>) -> Result<(), String> {
+    let settings_path = paths::get_droidgear_settings_path_for_home(home_dir);
     let mut settings = paths::read_droidgear_settings_from_path_internal(&settings_path)?;
 
     if let Some(obj) = settings.as_object_mut() {
@@ -101,6 +124,10 @@ fn save_active_file_name(name: Option<&str>) -> Result<(), String> {
 
     paths::write_droidgear_settings_to_path_internal(&settings_path, &settings)?;
     Ok(())
+}
+
+fn save_active_file_name(name: Option<&str>) -> Result<(), String> {
+    save_active_file_name_for_home(&system_home_dir()?, name)
 }
 
 // ============================================================================
@@ -161,21 +188,50 @@ pub fn get_active_settings_file() -> Result<SettingsFileInfo, String> {
 
 /// Set the active settings file.
 /// Pass `None` or empty string to switch to Global.
-pub fn set_active_settings_file(name: Option<String>) -> Result<SettingsFileInfo, String> {
+pub(crate) fn set_active_settings_file_for_home(
+    home_dir: &Path,
+    name: Option<String>,
+) -> Result<SettingsFileInfo, String> {
     match &name {
         Some(n) if !n.is_empty() => {
-            let path = droid_settings_dir()?.join(n).with_extension("json");
+            let path = droid_settings_dir_for_home(home_dir)
+                .join(n)
+                .with_extension("json");
             if !path.exists() {
                 return Err(format!("Settings file '{}' does not exist", n));
             }
-            save_active_file_name(Some(n))?;
+            save_active_file_name_for_home(home_dir, Some(n))?;
         }
         _ => {
-            save_active_file_name(None)?;
+            save_active_file_name_for_home(home_dir, None)?;
         }
     }
 
-    get_active_settings_file()
+    let active_path = get_active_settings_path_for_home(home_dir)?;
+    let global_path = global_settings_path_for_home(home_dir);
+
+    Ok(SettingsFileInfo {
+        name: if active_path == global_path {
+            "Global".to_string()
+        } else {
+            active_path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        },
+        path: active_path.to_string_lossy().to_string(),
+        is_global: active_path == global_path,
+        is_active: true,
+        exists: active_path.exists(),
+    })
+}
+
+/// Set the active settings file.
+/// Pass `None` or empty string to switch to Global.
+pub fn set_active_settings_file(name: Option<String>) -> Result<SettingsFileInfo, String> {
+    let _ = droid_settings_dir()?;
+    set_active_settings_file_for_home(&system_home_dir()?, name)
 }
 
 /// Create a new settings file.
@@ -245,20 +301,23 @@ pub fn delete_settings_file(name: String) -> Result<(), String> {
 
 /// Get the launch command for Droid with the active settings file.
 /// Returns the command string and the settings path used.
-pub fn get_launch_command() -> Result<(String, String), String> {
-    let active_path = get_active_settings_path()?;
+fn get_launch_command_for_home(home_dir: &Path) -> Result<(String, String), String> {
+    let active_path = get_active_settings_path_for_home(home_dir)?;
     let path_str = active_path.to_string_lossy().to_string();
 
-    let is_global = {
-        let global = global_settings_path()?;
-        active_path == global
-    };
+    let is_global = active_path == global_settings_path_for_home(home_dir);
 
     let command = if is_global {
         "droid".to_string()
     } else {
-        format!("droid --settings \"{}\"", path_str)
+        format!("droid --settings \"{path_str}\"")
     };
 
     Ok((command, path_str))
+}
+
+/// Get the launch command for Droid with the active settings file.
+/// Returns the command string and the settings path used.
+pub fn get_launch_command() -> Result<(String, String), String> {
+    get_launch_command_for_home(&system_home_dir()?)
 }

--- a/src-tauri/crates/droidgear-core/src/droid_settings_files.rs
+++ b/src-tauri/crates/droidgear-core/src/droid_settings_files.rs
@@ -60,14 +60,9 @@ fn global_settings_path_for_home(home_dir: &Path) -> PathBuf {
     home_dir.join(".factory").join("settings.json")
 }
 
-fn global_settings_path() -> Result<PathBuf, String> {
-    let home = system_home_dir()?;
-    Ok(global_settings_path_for_home(&home))
-}
-
 /// Resolves the absolute path to the currently active settings file.
 /// Returns the global path if no custom file is set, or if the active file doesn't exist.
-pub(crate) fn get_active_settings_path_for_home(home_dir: &Path) -> Result<PathBuf, String> {
+pub fn get_active_settings_path_for_home(home_dir: &Path) -> Result<PathBuf, String> {
     let active_name = load_active_file_name_for_home(home_dir)?;
     match active_name {
         Some(name) if !name.is_empty() => {
@@ -136,8 +131,13 @@ fn save_active_file_name(name: Option<&str>) -> Result<(), String> {
 
 /// List all available settings files (global + custom files)
 pub fn list_settings_files() -> Result<Vec<SettingsFileInfo>, String> {
-    let active_name = load_active_file_name().unwrap_or(None);
-    let global_path = global_settings_path()?;
+    list_settings_files_for_home(&system_home_dir()?)
+}
+
+/// List all available settings files (global + custom files) for a specific home directory.
+pub fn list_settings_files_for_home(home_dir: &Path) -> Result<Vec<SettingsFileInfo>, String> {
+    let active_path = get_active_settings_path_for_home(home_dir)?;
+    let global_path = global_settings_path_for_home(home_dir);
     let mut files = Vec::new();
 
     // Global file
@@ -145,12 +145,12 @@ pub fn list_settings_files() -> Result<Vec<SettingsFileInfo>, String> {
         name: "Global".to_string(),
         path: global_path.to_string_lossy().to_string(),
         is_global: true,
-        is_active: active_name.is_none(),
+        is_active: active_path == global_path,
         exists: global_path.exists(),
     });
 
     // Custom files from ~/.droidgear/droid-settings/
-    let dir = droid_settings_dir()?;
+    let dir = droid_settings_dir_for_home(home_dir);
     if dir.exists() {
         if let Ok(entries) = std::fs::read_dir(&dir) {
             for entry in entries.flatten() {
@@ -161,7 +161,7 @@ pub fn list_settings_files() -> Result<Vec<SettingsFileInfo>, String> {
                         .and_then(|s| s.to_str())
                         .unwrap_or("unknown")
                         .to_string();
-                    let is_active = active_name.as_deref() == Some(&name);
+                    let is_active = active_path == path;
                     files.push(SettingsFileInfo {
                         name: name.clone(),
                         path: path.to_string_lossy().to_string(),
@@ -179,16 +179,38 @@ pub fn list_settings_files() -> Result<Vec<SettingsFileInfo>, String> {
 
 /// Get the currently active settings file info
 pub fn get_active_settings_file() -> Result<SettingsFileInfo, String> {
-    let files = list_settings_files()?;
+    get_active_settings_file_for_home(&system_home_dir()?)
+}
+
+/// Get the currently active settings file info for a specific home directory.
+pub fn get_active_settings_file_for_home(home_dir: &Path) -> Result<SettingsFileInfo, String> {
+    let files = list_settings_files_for_home(home_dir)?;
     files
         .into_iter()
         .find(|f| f.is_active)
         .ok_or_else(|| "No active settings file found".to_string())
 }
 
+/// Resolve a settings file path by display name for a specific home directory.
+/// Accepts `Global` (case-insensitive) for the global Factory settings file.
+pub fn get_settings_path_by_name_for_home(home_dir: &Path, name: &str) -> Result<PathBuf, String> {
+    if name.eq_ignore_ascii_case("global") {
+        return Ok(global_settings_path_for_home(home_dir));
+    }
+
+    let path = droid_settings_dir_for_home(home_dir)
+        .join(name)
+        .with_extension("json");
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(format!("Settings file '{name}' does not exist"))
+    }
+}
+
 /// Set the active settings file.
 /// Pass `None` or empty string to switch to Global.
-pub(crate) fn set_active_settings_file_for_home(
+pub fn set_active_settings_file_for_home(
     home_dir: &Path,
     name: Option<String>,
 ) -> Result<SettingsFileInfo, String> {
@@ -301,7 +323,7 @@ pub fn delete_settings_file(name: String) -> Result<(), String> {
 
 /// Get the launch command for Droid with the active settings file.
 /// Returns the command string and the settings path used.
-fn get_launch_command_for_home(home_dir: &Path) -> Result<(String, String), String> {
+pub fn get_launch_command_for_home(home_dir: &Path) -> Result<(String, String), String> {
     let active_path = get_active_settings_path_for_home(home_dir)?;
     let path_str = active_path.to_string_lossy().to_string();
 
@@ -320,4 +342,69 @@ fn get_launch_command_for_home(home_dir: &Path) -> Result<(String, String), Stri
 /// Returns the command string and the settings path used.
 pub fn get_launch_command() -> Result<(String, String), String> {
     get_launch_command_for_home(&system_home_dir()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        get_active_settings_file_for_home, get_settings_path_by_name_for_home,
+        list_settings_files_for_home, set_active_settings_file_for_home,
+    };
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn list_settings_files_for_home_uses_the_provided_home_directory() {
+        let temp = TempDir::new().unwrap();
+        let home_dir = temp.path();
+
+        write_file(&home_dir.join(".factory/settings.json"), "{}");
+        write_file(
+            &home_dir.join(".droidgear/droid-settings/profile-a.json"),
+            "{}",
+        );
+        set_active_settings_file_for_home(home_dir, Some("profile-a".to_string())).unwrap();
+
+        let files = list_settings_files_for_home(home_dir).unwrap();
+
+        assert_eq!(files.len(), 2);
+        assert!(files
+            .iter()
+            .any(|file| file.name == "Global" && file.is_global));
+        assert!(files
+            .iter()
+            .any(|file| file.name == "profile-a" && file.is_active));
+
+        let active = get_active_settings_file_for_home(home_dir).unwrap();
+        assert_eq!(active.name, "profile-a");
+        assert!(!active.is_global);
+    }
+
+    #[test]
+    fn get_settings_path_by_name_for_home_resolves_global_and_custom_files() {
+        let temp = TempDir::new().unwrap();
+        let home_dir = temp.path();
+
+        let global_path = home_dir.join(".factory/settings.json");
+        let custom_path = home_dir.join(".droidgear/droid-settings/profile-b.json");
+        write_file(&global_path, "{}");
+        write_file(&custom_path, "{}");
+
+        assert_eq!(
+            get_settings_path_by_name_for_home(home_dir, "global").unwrap(),
+            global_path
+        );
+        assert_eq!(
+            get_settings_path_by_name_for_home(home_dir, "profile-b").unwrap(),
+            custom_path
+        );
+        assert!(get_settings_path_by_name_for_home(home_dir, "missing").is_err());
+    }
 }

--- a/src-tauri/crates/droidgear-core/src/lib.rs
+++ b/src-tauri/crates/droidgear-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod channel;
 pub mod codex;
 pub mod codex_runtime;
 pub mod connectivity;
+pub mod droid_runtime;
 pub mod droid_settings_files;
 pub mod factory_settings;
 pub mod hermes;

--- a/src-tauri/crates/droidgear-tui/src/main.rs
+++ b/src-tauri/crates/droidgear-tui/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Run a temporary Codex session in the current terminal and exit
+    /// Run a temporary Droid/Codex session in the current terminal and exit
     Run {
         #[command(subcommand)]
         target: RunTarget,
@@ -36,6 +36,12 @@ enum RunTarget {
         #[arg(long)]
         list: bool,
         profile: Option<String>,
+    },
+    /// Run a Droid settings file by name (use `global` for ~/.factory/settings.json)
+    Droid {
+        #[arg(long)]
+        list: bool,
+        settings_name: Option<String>,
     },
 }
 
@@ -61,6 +67,23 @@ fn main() -> anyhow::Result<()> {
                         "Missing Codex target. Use `droidgear-tui run codex --list` to inspect available profiles.",
                     )?;
                     tui::run_codex_temporary_run_for_selector(&home_dir, &profile)
+                }
+            }
+            RunTarget::Droid {
+                list,
+                settings_name,
+            } => {
+                if list {
+                    if settings_name.is_some() {
+                        bail!("`--list` cannot be combined with a Droid target");
+                    }
+                    println!("{}", tui::list_droid_temporary_run_targets(&home_dir)?);
+                    Ok(())
+                } else {
+                    let settings_name = settings_name.context(
+                        "Missing Droid target. Use `droidgear-tui run droid --list` to inspect available settings names.",
+                    )?;
+                    tui::run_droid_temporary_run_for_settings_name(&home_dir, &settings_name)
                 }
             }
         },
@@ -109,6 +132,25 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_droid_run_subcommand() {
+        let cli = Cli::parse_from(["droidgear-tui", "run", "droid", "global"]);
+
+        match cli.command {
+            Some(Command::Run {
+                target:
+                    RunTarget::Droid {
+                        list,
+                        settings_name,
+                    },
+            }) => {
+                assert!(!list);
+                assert_eq!(settings_name.as_deref(), Some("global"));
+            }
+            _ => panic!("expected droid run subcommand"),
+        }
+    }
+
+    #[test]
     fn cli_parses_codex_list_subcommand() {
         let cli = Cli::parse_from(["droidgear-tui", "run", "codex", "--list"]);
 
@@ -120,6 +162,25 @@ mod tests {
                 assert!(profile.is_none());
             }
             _ => panic!("expected codex list subcommand"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_droid_list_subcommand() {
+        let cli = Cli::parse_from(["droidgear-tui", "run", "droid", "--list"]);
+
+        match cli.command {
+            Some(Command::Run {
+                target:
+                    RunTarget::Droid {
+                        list,
+                        settings_name,
+                    },
+            }) => {
+                assert!(list);
+                assert!(settings_name.is_none());
+            }
+            _ => panic!("expected droid list subcommand"),
         }
     }
 }

--- a/src-tauri/crates/droidgear-tui/src/tui.rs
+++ b/src-tauri/crates/droidgear-tui/src/tui.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use tempfile::{NamedTempFile, TempDir};
 
 type UiTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+const APP_IDENTIFIER: &str = "com.droidgear.app";
 
 struct TerminalGuard;
 
@@ -4634,6 +4635,70 @@ fn write_string(path: &Path, content: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Default, serde::Deserialize)]
+struct StoredPreferences {
+    #[serde(default)]
+    droid_run: Option<droidgear_core::droid_runtime::DroidRunPreferences>,
+}
+
+fn preferences_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|dir| dir.join(APP_IDENTIFIER).join("preferences.json"))
+}
+
+fn load_droid_run_preferences_from_path(
+    path: &Path,
+) -> anyhow::Result<droidgear_core::droid_runtime::DroidRunPreferences> {
+    if !path.exists() {
+        return Ok(droidgear_core::droid_runtime::DroidRunPreferences::default());
+    }
+
+    let contents =
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let prefs: StoredPreferences =
+        serde_json::from_str(&contents).with_context(|| format!("parse {}", path.display()))?;
+    Ok(prefs.droid_run.unwrap_or_default())
+}
+
+fn load_droid_run_preferences() -> anyhow::Result<droidgear_core::droid_runtime::DroidRunPreferences>
+{
+    let Some(path) = preferences_path() else {
+        return Ok(droidgear_core::droid_runtime::DroidRunPreferences::default());
+    };
+
+    load_droid_run_preferences_from_path(&path)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn format_string_list(values: &[String], empty_label: &str) -> String {
+    if values.is_empty() {
+        return format!("  {empty_label}\n");
+    }
+
+    let mut out = String::new();
+    for value in values {
+        out.push_str("  - ");
+        out.push_str(value);
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn format_env_pairs(values: &[(String, String)], empty_label: &str) -> String {
+    if values.is_empty() {
+        return format!("  {empty_label}\n");
+    }
+
+    let mut out = String::new();
+    for (key, value) in values {
+        out.push_str("  - ");
+        out.push_str(key);
+        out.push('=');
+        out.push_str(value);
+        out.push('\n');
+    }
+    out
+}
 fn start_command_in_foreground(
     program: &str,
     args: &[String],
@@ -4707,6 +4772,88 @@ fn format_diff_report(title: &str, files: Vec<(String, Option<String>, Option<St
     }
 
     out
+}
+
+fn build_droid_temporary_run_plan(
+    home_dir: &Path,
+    settings_path: &Path,
+) -> anyhow::Result<droidgear_core::droid_runtime::DroidTemporaryRunPlan> {
+    let prefs = load_droid_run_preferences()?;
+    droidgear_core::droid_runtime::cleanup_stale_temp_settings_for_home(home_dir)
+        .map_err(anyhow::Error::msg)?;
+    droidgear_core::droid_runtime::build_temporary_run_plan_from_settings_path_for_home(
+        home_dir,
+        settings_path,
+        &prefs,
+    )
+    .map_err(anyhow::Error::msg)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn preview_droid_temporary_run(home_dir: &Path, settings_path: &Path) -> anyhow::Result<String> {
+    let plan = build_droid_temporary_run_plan(home_dir, settings_path)?;
+
+    let mut out = String::new();
+    out.push_str("Droid temporary run preview\n\n");
+    out.push_str(&format!(
+        "Source settings path:\n  {}\n\n",
+        settings_path.display()
+    ));
+    out.push_str(&format!(
+        "Temporary settings path:\n  {}\n\n",
+        plan.temp_settings_path.display()
+    ));
+    out.push_str("Program:\n");
+    out.push_str(&format!("  {}\n\n", plan.program));
+    out.push_str("Args:\n");
+    out.push_str(&format_string_list(&plan.args, "(none)"));
+    out.push('\n');
+    out.push_str("Environment overrides:\n");
+    out.push_str(&format_env_pairs(&plan.env, "(none)"));
+    out.push('\n');
+    out.push_str("Unset environment variables:\n");
+    out.push_str(&format_string_list(&plan.unset_env, "(none)"));
+
+    Ok(out)
+}
+
+fn run_droid_temporary_run(home_dir: &Path, settings_path: &Path) -> anyhow::Result<()> {
+    let plan = build_droid_temporary_run_plan(home_dir, settings_path)?;
+    start_command_in_foreground(
+        &plan.program,
+        &plan.args,
+        &plan.env,
+        &[],
+        &plan.unset_env,
+        None,
+    )
+}
+
+pub fn run_droid_temporary_run_for_settings_name(
+    home_dir: &Path,
+    settings_name: &str,
+) -> anyhow::Result<()> {
+    let settings_path = droidgear_core::droid_settings_files::get_settings_path_by_name_for_home(
+        home_dir,
+        settings_name,
+    )
+    .map_err(anyhow::Error::msg)?;
+    run_droid_temporary_run(home_dir, &settings_path)
+}
+
+pub fn list_droid_temporary_run_targets(home_dir: &Path) -> anyhow::Result<String> {
+    let files = droidgear_core::droid_settings_files::list_settings_files_for_home(home_dir)
+        .map_err(anyhow::Error::msg)?;
+
+    let mut out = String::from("Available Droid run targets:\n");
+    for file in files {
+        let marker = if file.is_active { "*" } else { " " };
+        let selector = if file.is_global { "global" } else { &file.name };
+        out.push_str(&format!("{marker} {selector}\n"));
+    }
+    out.push_str("\nUse `droidgear-tui run droid <settings-name>`.\n");
+    out.push_str("`*` marks the currently active settings file.");
+    Ok(out)
 }
 
 fn preview_codex_apply(home_dir: &Path, profile_id: &str) -> anyhow::Result<String> {
@@ -7749,7 +7896,15 @@ fn factory_model_id(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::path::Path;
     use tempfile::TempDir;
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
 
     #[test]
     fn normalize_factory_models_sets_index_and_id() {
@@ -7989,6 +8144,71 @@ mod tests {
             profile_id: "x".to_string(),
             provider_id: "y".to_string(),
         };
+    }
+
+    #[test]
+    fn load_droid_run_preferences_from_path_reads_nested_policy() {
+        let temp = TempDir::new().unwrap();
+        let prefs_path = temp.path().join("preferences.json");
+        write_file(
+            &prefs_path,
+            r#"{
+  "theme": "system",
+  "droid_run": {
+    "disableAutoUpdateEnv": false,
+    "unsetAnthropicAuthToken": true
+  }
+}"#,
+        );
+
+        let prefs = load_droid_run_preferences_from_path(&prefs_path).unwrap();
+        assert_eq!(
+            prefs,
+            droidgear_core::droid_runtime::DroidRunPreferences {
+                disable_auto_update_env: Some(false),
+                unset_anthropic_auth_token: Some(true),
+            }
+        );
+    }
+
+    #[test]
+    fn preview_droid_temporary_run_uses_selected_settings_path_without_dumping_contents() {
+        let temp = TempDir::new().unwrap();
+        let settings_path = temp.path().join(".droidgear/droid-settings/profile-a.json");
+        write_file(
+            &settings_path,
+            r#"{"apiKey":"sk-droid-secret","model":"demo"}"#,
+        );
+
+        let preview = preview_droid_temporary_run(temp.path(), &settings_path).unwrap();
+
+        assert!(preview.contains("Droid temporary run preview"));
+        assert!(preview.contains(settings_path.to_string_lossy().as_ref()));
+        assert!(preview.contains("FACTORY_DROID_AUTO_UPDATE_ENABLED=0"));
+        assert!(preview.contains("ANTHROPIC_AUTH_TOKEN"));
+        assert!(!preview.contains("sk-droid-secret"));
+    }
+
+    #[test]
+    fn list_droid_temporary_run_targets_lists_global_and_custom_names() {
+        let temp = TempDir::new().unwrap();
+        write_file(&temp.path().join(".factory/settings.json"), "{}");
+        write_file(
+            &temp.path().join(".droidgear/droid-settings/profile-a.json"),
+            "{}",
+        );
+        droidgear_core::droid_settings_files::set_active_settings_file_for_home(
+            temp.path(),
+            Some("profile-a".to_string()),
+        )
+        .unwrap();
+
+        let output = list_droid_temporary_run_targets(temp.path()).unwrap();
+
+        assert!(output.contains("Available Droid run targets:"));
+        assert!(output.contains(" global"));
+        assert!(output.contains("* profile-a"));
+        assert!(output.contains("run droid <settings-name>"));
     }
 
     #[test]

--- a/src-tauri/src/commands/droid_settings.rs
+++ b/src-tauri/src/commands/droid_settings.rs
@@ -5,8 +5,8 @@
 pub use droidgear_core::droid_settings_files::SettingsFileInfo;
 
 use droidgear_core::{droid_runtime, droid_settings_files};
-use tauri::Manager;
 
+use crate::utils::preferences::load_preferences;
 use crate::utils::terminal_launch::{launch_in_terminal, LaunchSpec};
 
 /// Lists all available Droid settings files (global + custom)
@@ -54,21 +54,25 @@ pub async fn delete_droid_settings_file(name: String) -> Result<(), String> {
 #[tauri::command]
 #[specta::specta]
 pub async fn get_droid_launch_command() -> Result<(String, String), String> {
-    droid_settings_files::get_launch_command()
+    let (command, path) = droid_settings_files::get_launch_command()?;
+    Ok((command, path))
 }
 
-/// Launches Droid CLI in a terminal using a temporary settings snapshot.
+/// Launches Droid CLI in a terminal with the active settings file.
+/// Respects the user's preferredTerminal preference.
 #[tauri::command]
 #[specta::specta]
 pub async fn launch_droid(app: tauri::AppHandle) -> Result<(), String> {
-    let preferred = load_preferred_terminal(&app).unwrap_or_default();
-    let home_dir = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
+    // Read preferred terminal from preferences
+    let prefs = load_preferences(&app).unwrap_or_default();
+    let preferred = prefs.preferred_terminal.unwrap_or_default();
+    let droid_run = prefs.droid_run.unwrap_or_default();
 
+    let home_dir = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
     if let Err(error) = droid_runtime::cleanup_stale_temp_settings_for_home(&home_dir) {
         log::warn!("Failed to clean up stale Droid temporary settings files: {error}");
     }
-
-    let plan = droid_runtime::build_temporary_run_plan_for_home(&home_dir)?;
+    let plan = droid_runtime::build_temporary_run_plan_for_home(&home_dir, &droid_run)?;
     let spec = build_droid_launch_spec(&plan);
 
     launch_in_terminal(&spec, &preferred)
@@ -79,45 +83,19 @@ fn build_droid_launch_spec(plan: &droid_runtime::DroidTemporaryRunPlan) -> Launc
         program: plan.program.clone(),
         args: plan.args.clone(),
         env: plan.env.clone(),
+        secret_env: Vec::new(),
         unset_env: plan.unset_env.clone(),
         cwd: None,
+        support_dir: None,
     }
-}
-
-fn load_preferred_terminal_from_path(prefs_path: &std::path::Path) -> Result<String, String> {
-    if !prefs_path.exists() {
-        return Ok(String::new());
-    }
-
-    let contents = std::fs::read_to_string(prefs_path)
-        .map_err(|e| format!("Failed to read preferences: {e}"))?;
-    let prefs: serde_json::Value = serde_json::from_str(&contents).map_err(|_e| String::new())?;
-
-    Ok(prefs
-        .get("preferred_terminal")
-        .and_then(|value| value.as_str())
-        .unwrap_or("")
-        .to_string())
-}
-
-fn load_preferred_terminal(app: &tauri::AppHandle) -> Result<String, String> {
-    let prefs_path = {
-        let app_data_dir = app
-            .path()
-            .app_data_dir()
-            .map_err(|e| format!("Failed to get app data dir: {e}"))?;
-        app_data_dir.join("preferences.json")
-    };
-
-    load_preferred_terminal_from_path(&prefs_path)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::build_droid_launch_spec;
+    use crate::utils::preferences::load_preferences_from_path;
+    use droidgear_core::droid_runtime::{DroidRunPreferences, DroidTemporaryRunPlan};
     use std::path::PathBuf;
-
-    use super::{build_droid_launch_spec, load_preferred_terminal_from_path};
-    use droidgear_core::droid_runtime::DroidTemporaryRunPlan;
 
     #[test]
     fn build_droid_launch_spec_preserves_temp_run_args_and_env() {
@@ -150,24 +128,34 @@ mod tests {
                 "0".to_string()
             )]
         );
+        assert!(spec.secret_env.is_empty());
         assert_eq!(spec.unset_env, vec!["ANTHROPIC_AUTH_TOKEN".to_string()]);
+        assert!(spec.support_dir.is_none());
     }
 
     #[test]
-    fn load_preferred_terminal_returns_empty_when_file_is_missing() {
+    fn droid_run_preferences_default_to_unconfigured_policy() {
+        let prefs = DroidRunPreferences::default();
+
+        assert!(prefs.disable_auto_update_env.is_none());
+        assert!(prefs.unset_anthropic_auth_token.is_none());
+    }
+
+    #[test]
+    fn load_preferences_returns_default_when_file_is_missing() {
         let path = std::env::temp_dir().join(format!(
             "droidgear-missing-prefs-{}.json",
             std::process::id()
         ));
         let _ = std::fs::remove_file(&path);
+        let prefs = load_preferences_from_path(&path).unwrap();
 
-        let preferred = load_preferred_terminal_from_path(&path).unwrap();
-
-        assert!(preferred.is_empty());
+        assert!(prefs.preferred_terminal.is_none());
+        assert!(prefs.droid_run.is_none());
     }
 
     #[test]
-    fn load_preferred_terminal_reads_existing_json_payload() {
+    fn load_preferences_reads_droid_run_policy_from_disk() {
         let path = std::env::temp_dir().join(format!(
             "droidgear-test-preferences-{}.json",
             std::time::SystemTime::now()
@@ -179,14 +167,25 @@ mod tests {
             &path,
             r#"{
               "theme": "system",
+              "droid_run": {
+                "disableAutoUpdateEnv": false,
+                "unsetAnthropicAuthToken": true
+              },
               "preferred_terminal": "terminal"
             }"#,
         )
         .unwrap();
 
-        let preferred = load_preferred_terminal_from_path(&path).unwrap();
+        let prefs = load_preferences_from_path(&path).unwrap();
         let _ = std::fs::remove_file(&path);
 
-        assert_eq!(preferred, "terminal");
+        assert_eq!(prefs.preferred_terminal.as_deref(), Some("terminal"));
+        assert_eq!(
+            prefs.droid_run,
+            Some(DroidRunPreferences {
+                disable_auto_update_env: Some(false),
+                unset_anthropic_auth_token: Some(true),
+            })
+        );
     }
 }

--- a/src-tauri/src/commands/droid_settings.rs
+++ b/src-tauri/src/commands/droid_settings.rs
@@ -4,8 +4,10 @@
 
 pub use droidgear_core::droid_settings_files::SettingsFileInfo;
 
-use droidgear_core::droid_settings_files;
+use droidgear_core::{droid_runtime, droid_settings_files};
 use tauri::Manager;
+
+use crate::utils::terminal_launch::{launch_in_terminal, LaunchSpec};
 
 /// Lists all available Droid settings files (global + custom)
 #[tauri::command]
@@ -55,17 +57,47 @@ pub async fn get_droid_launch_command() -> Result<(String, String), String> {
     droid_settings_files::get_launch_command()
 }
 
-/// Launches Droid CLI in a terminal with the active settings file.
-/// Respects the user's preferredTerminal preference.
+/// Launches Droid CLI in a terminal using a temporary settings snapshot.
 #[tauri::command]
 #[specta::specta]
 pub async fn launch_droid(app: tauri::AppHandle) -> Result<(), String> {
-    let (command, _path) = droid_settings_files::get_launch_command()?;
-
-    // Read preferred terminal from preferences
     let preferred = load_preferred_terminal(&app).unwrap_or_default();
+    let home_dir = dirs::home_dir().ok_or_else(|| "Failed to get home directory".to_string())?;
 
-    launch_droid_in_terminal(&command, &preferred)
+    if let Err(error) = droid_runtime::cleanup_stale_temp_settings_for_home(&home_dir) {
+        log::warn!("Failed to clean up stale Droid temporary settings files: {error}");
+    }
+
+    let plan = droid_runtime::build_temporary_run_plan_for_home(&home_dir)?;
+    let spec = build_droid_launch_spec(&plan);
+
+    launch_in_terminal(&spec, &preferred)
+}
+
+fn build_droid_launch_spec(plan: &droid_runtime::DroidTemporaryRunPlan) -> LaunchSpec {
+    LaunchSpec {
+        program: plan.program.clone(),
+        args: plan.args.clone(),
+        env: plan.env.clone(),
+        unset_env: plan.unset_env.clone(),
+        cwd: None,
+    }
+}
+
+fn load_preferred_terminal_from_path(prefs_path: &std::path::Path) -> Result<String, String> {
+    if !prefs_path.exists() {
+        return Ok(String::new());
+    }
+
+    let contents = std::fs::read_to_string(prefs_path)
+        .map_err(|e| format!("Failed to read preferences: {e}"))?;
+    let prefs: serde_json::Value = serde_json::from_str(&contents).map_err(|_e| String::new())?;
+
+    Ok(prefs
+        .get("preferred_terminal")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string())
 }
 
 fn load_preferred_terminal(app: &tauri::AppHandle) -> Result<String, String> {
@@ -77,265 +109,84 @@ fn load_preferred_terminal(app: &tauri::AppHandle) -> Result<String, String> {
         app_data_dir.join("preferences.json")
     };
 
-    if !prefs_path.exists() {
-        return Ok(String::new());
-    }
-
-    let contents = std::fs::read_to_string(&prefs_path)
-        .map_err(|e| format!("Failed to read preferences: {e}"))?;
-    let prefs: serde_json::Value = serde_json::from_str(&contents).map_err(|_e| String::new())?;
-
-    Ok(prefs
-        .get("preferred_terminal")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string())
+    load_preferred_terminal_from_path(&prefs_path)
 }
 
-fn launch_droid_in_terminal(command: &str, preferred: &str) -> Result<(), String> {
-    #[cfg(target_os = "macos")]
-    {
-        launch_macos(command, preferred)
-    }
-    #[cfg(target_os = "linux")]
-    {
-        launch_linux(command, preferred)
-    }
-    #[cfg(target_os = "windows")]
-    {
-        launch_windows(command, preferred)
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        Err("Unsupported platform".to_string())
-    }
-}
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
 
-// ============================================================================
-// macOS
-// ============================================================================
+    use super::{build_droid_launch_spec, load_preferred_terminal_from_path};
+    use droidgear_core::droid_runtime::DroidTemporaryRunPlan;
 
-#[cfg(target_os = "macos")]
-fn launch_macos(command: &str, preferred: &str) -> Result<(), String> {
-    match preferred {
-        "iterm2" => launch_iterm2(command),
-        "terminal" => launch_terminal_app(command),
-        _ => launch_system_default_macos(command), // "system-default" or empty
-    }
-}
+    #[test]
+    fn build_droid_launch_spec_preserves_temp_run_args_and_env() {
+        let spec = build_droid_launch_spec(&DroidTemporaryRunPlan {
+            program: "droid".to_string(),
+            args: vec![
+                "--settings".to_string(),
+                "/tmp/runtime/droid/temporary-run.json".to_string(),
+            ],
+            env: vec![(
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED".to_string(),
+                "0".to_string(),
+            )],
+            unset_env: vec!["ANTHROPIC_AUTH_TOKEN".to_string()],
+            temp_settings_path: PathBuf::from("/tmp/runtime/droid/temporary-run.json"),
+        });
 
-#[cfg(target_os = "macos")]
-fn launch_iterm2(command: &str) -> Result<(), String> {
-    let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
-    // Try to create a new tab in the current window; if iTerm2 isn't running, it will launch
-    let script = format!(
-        r#"tell application "iTerm2"
-    if (count of windows) = 0 then
-        create window with default profile
-    end if
-    tell current window
-        create tab with default profile
-        tell current session
-            write text "clear; echo 'Starting Droid...'; {}; exit"
-        end tell
-    end tell
-    activate
-end tell"#,
-        escaped
-    );
-
-    let status = std::process::Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .status()
-        .map_err(|e| format!("Failed to launch iTerm2: {e}"))?;
-
-    if !status.success() {
-        // Fallback: try launching iTerm2 directly
-        let status2 = std::process::Command::new("open")
-            .args([
-                "-a",
-                "iTerm",
-                "--args",
-                "bash",
-                "-c",
-                &format!("{}; exec bash", command),
-            ])
-            .status()
-            .map_err(|e| format!("Failed to launch iTerm2: {e}"))?;
-        if !status2.success() {
-            return Err("Failed to launch iTerm2".to_string());
-        }
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn launch_terminal_app(command: &str) -> Result<(), String> {
-    let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
-    let script = format!(
-        r#"tell application "Terminal"
-    activate
-    do script "clear; echo 'Starting Droid...'; {}; exit"
-end tell"#,
-        escaped
-    );
-
-    let status = std::process::Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .status()
-        .map_err(|e| format!("Failed to launch Terminal: {e}"))?;
-
-    if !status.success() {
-        return Err("Failed to open Terminal".to_string());
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn launch_system_default_macos(command: &str) -> Result<(), String> {
-    // Create a temporary .command file and open it with the system default handler
-    let tmp_dir = std::env::temp_dir();
-    let file_path = tmp_dir.join("droid-launch.command");
-    let script_content = format!(
-        "#!/bin/bash\nclear\necho 'Starting Droid...'\n{}\nexit\n",
-        command
-    );
-    std::fs::write(&file_path, script_content)
-        .map_err(|e| format!("Failed to create launch script: {e}"))?;
-
-    // Make it executable
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&file_path)
-            .map_err(|e| format!("Failed to read metadata: {e}"))?
-            .permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&file_path, perms)
-            .map_err(|e| format!("Failed to set permissions: {e}"))?;
-    }
-
-    let status = std::process::Command::new("open")
-        .arg(&file_path)
-        .status()
-        .map_err(|e| format!("Failed to open terminal: {e}"))?;
-
-    if !status.success() {
-        return Err("Failed to open terminal".to_string());
-    }
-    Ok(())
-}
-
-// ============================================================================
-// Linux
-// ============================================================================
-
-#[cfg(target_os = "linux")]
-fn launch_linux(command: &str, preferred: &str) -> Result<(), String> {
-    let bash_script = format!("{}; exec bash", command);
-    let xfce_script = format!("bash -c '{}; exec bash'", command);
-
-    let terminals: Vec<(&str, Vec<&str>)> = match preferred {
-        "gnome-terminal" => vec![(
-            "gnome-terminal",
-            vec!["--tab", "--", "bash", "-c", &bash_script],
-        )],
-        "konsole" => vec![(
-            "konsole",
-            vec!["--new-tab", "-e", "bash", "-c", &bash_script],
-        )],
-        "xfce4-terminal" => vec![("xfce4-terminal", vec!["--tab", "-e", &xfce_script])],
-        "x-terminal-emulator" => vec![(
-            "x-terminal-emulator",
-            vec!["-e", "bash", "-c", &bash_script],
-        )],
-        _ => {
-            // auto-detect or empty — try common terminals in order
+        assert_eq!(spec.program, "droid");
+        assert_eq!(
+            spec.args,
             vec![
-                (
-                    "gnome-terminal",
-                    vec!["--tab", "--", "bash", "-c", &bash_script],
-                ),
-                (
-                    "konsole",
-                    vec!["--new-tab", "-e", "bash", "-c", &bash_script],
-                ),
-                ("xfce4-terminal", vec!["--tab", "-e", &xfce_script]),
-                (
-                    "x-terminal-emulator",
-                    vec!["-e", "bash", "-c", &bash_script],
-                ),
-                ("xterm", vec!["-e", "bash", "-c", &bash_script]),
+                "--settings".to_string(),
+                "/tmp/runtime/droid/temporary-run.json".to_string()
             ]
-        }
-    };
-
-    let mut last_err = String::new();
-    for (term, args) in &terminals {
-        let args: Vec<&str> = args.iter().map(|s| *s).collect();
-        match std::process::Command::new(term).args(&args).spawn() {
-            Ok(_) => return Ok(()),
-            Err(e) => {
-                last_err = format!("{term}: {e}");
-            }
-        }
+        );
+        assert_eq!(
+            spec.env,
+            vec![(
+                "FACTORY_DROID_AUTO_UPDATE_ENABLED".to_string(),
+                "0".to_string()
+            )]
+        );
+        assert_eq!(spec.unset_env, vec!["ANTHROPIC_AUTH_TOKEN".to_string()]);
     }
-    Err(format!(
-        "Could not find a terminal emulator. Tried: {last_err}"
-    ))
-}
 
-// ============================================================================
-// Windows
-// ============================================================================
+    #[test]
+    fn load_preferred_terminal_returns_empty_when_file_is_missing() {
+        let path = std::env::temp_dir().join(format!(
+            "droidgear-missing-prefs-{}.json",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
 
-#[cfg(target_os = "windows")]
-fn launch_windows(command: &str, preferred: &str) -> Result<(), String> {
-    match preferred {
-        "cmd" => {
-            std::process::Command::new("cmd")
-                .args(["/c", "start", "cmd", "/k", command])
-                .spawn()
-                .map_err(|e| format!("Failed to launch cmd: {e}"))?;
-            Ok(())
-        }
-        "powershell" => {
-            std::process::Command::new("powershell")
-                .args([
-                    "-NoExit",
-                    "-Command",
-                    &format!("Write-Host 'Starting Droid...'; {}", command),
-                ])
-                .spawn()
-                .map_err(|e| format!("Failed to launch PowerShell: {e}"))?;
-            Ok(())
-        }
-        _ => {
-            // "windows-terminal" or empty — try Windows Terminal first, fall back to cmd
-            let wt_status = std::process::Command::new("wt")
-                .args(["-w", "0", "new-tab", "cmd", "/k", command])
-                .spawn();
+        let preferred = load_preferred_terminal_from_path(&path).unwrap();
 
-            if wt_status.is_ok() {
-                return Ok(());
-            }
+        assert!(preferred.is_empty());
+    }
 
-            // Fallback: try launching Windows Terminal without -w flag (first launch)
-            let wt_status2 = std::process::Command::new("wt")
-                .args(["cmd", "/k", command])
-                .spawn();
+    #[test]
+    fn load_preferred_terminal_reads_existing_json_payload() {
+        let path = std::env::temp_dir().join(format!(
+            "droidgear-test-preferences-{}.json",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(
+            &path,
+            r#"{
+              "theme": "system",
+              "preferred_terminal": "terminal"
+            }"#,
+        )
+        .unwrap();
 
-            if wt_status2.is_ok() {
-                return Ok(());
-            }
+        let preferred = load_preferred_terminal_from_path(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
 
-            std::process::Command::new("cmd")
-                .args(["/c", "start", "cmd", "/k", command])
-                .spawn()
-                .map_err(|e| format!("Failed to launch command prompt: {e}"))?;
-            Ok(())
-        }
+        assert_eq!(preferred, "terminal");
     }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -1,5 +1,6 @@
 //! Shared types and validation functions for the Tauri application.
 
+use droidgear_core::droid_runtime::DroidRunPreferences;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -47,6 +48,9 @@ pub struct AppPreferences {
     /// If None, defaults to platform-appropriate default
     #[serde(default)]
     pub preferred_terminal: Option<String>,
+    /// Droid temporary-run runtime policy.
+    #[serde(default)]
+    pub droid_run: Option<DroidRunPreferences>,
 }
 
 impl Default for AppPreferences {
@@ -58,6 +62,7 @@ impl Default for AppPreferences {
             terminal_shell_command: None, // None means use default shell
             disable_auto_update: None,    // None means auto-update enabled (default)
             preferred_terminal: None,     // None means platform default
+            droid_run: None,
         }
     }
 }

--- a/src-tauri/src/utils/preferences.rs
+++ b/src-tauri/src/utils/preferences.rs
@@ -26,6 +26,7 @@ pub fn load_preferences(app: &tauri::AppHandle) -> Result<AppPreferences, String
 #[cfg(test)]
 mod tests {
     use super::load_preferences_from_path;
+    use droidgear_core::droid_runtime::DroidRunPreferences;
 
     #[test]
     fn load_preferences_returns_default_when_file_is_missing() {
@@ -37,7 +38,7 @@ mod tests {
         let prefs = load_preferences_from_path(&path).unwrap();
 
         assert!(prefs.preferred_terminal.is_none());
-        assert_eq!(prefs.theme, "system");
+        assert!(prefs.droid_run.is_none());
     }
 
     #[test]
@@ -53,6 +54,10 @@ mod tests {
             &path,
             r#"{
               "theme": "system",
+              "droid_run": {
+                "disableAutoUpdateEnv": false,
+                "unsetAnthropicAuthToken": true
+              },
               "preferred_terminal": "terminal"
             }"#,
         )
@@ -62,6 +67,12 @@ mod tests {
         let _ = std::fs::remove_file(&path);
 
         assert_eq!(prefs.preferred_terminal.as_deref(), Some("terminal"));
-        assert_eq!(prefs.theme, "system");
+        assert_eq!(
+            prefs.droid_run,
+            Some(DroidRunPreferences {
+                disable_auto_update_env: Some(false),
+                unset_anthropic_auth_token: Some(true),
+            })
+        );
     }
 }

--- a/src/components/droid/DroidFeatureList.test.tsx
+++ b/src/components/droid/DroidFeatureList.test.tsx
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+
+const { toastMock, writeTextMock } = vi.hoisted(() => {
+  const toast = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    dismiss: vi.fn(),
+    loading: vi.fn(),
+  })
+
+  return {
+    toastMock: toast,
+    writeTextMock: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: toastMock,
+}))
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  writeText: writeTextMock,
+}))
+
+import { render, screen, waitFor } from '@/test/test-utils'
+import { commands } from '@/lib/tauri-bindings'
+import { useModelStore } from '@/store/model-store'
+import { useUIStore } from '@/store/ui-store'
+import { DroidFeatureList } from './DroidFeatureList'
+
+describe('DroidFeatureList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+
+    useUIStore.setState({
+      currentView: 'droid',
+      lastToolView: 'droid',
+      droidSubView: 'models',
+      leftSidebarVisible: true,
+      rightSidebarVisible: false,
+      commandPaletteOpen: false,
+      preferencesOpen: false,
+      lastSpecExportPath: null,
+      pendingUpdate: null,
+      droidSettingsScrollTarget: null,
+      droidRefreshKey: 0,
+    })
+    useModelStore.setState(useModelStore.getInitialState())
+
+    vi.mocked(commands.listDroidSettingsFiles).mockResolvedValue({
+      status: 'ok',
+      data: [
+        {
+          name: 'Global',
+          path: '/home/user/.factory/settings.json',
+          isGlobal: true,
+          isActive: true,
+          exists: true,
+        },
+      ],
+    })
+    vi.mocked(commands.launchDroid).mockResolvedValue({
+      status: 'ok',
+      data: null,
+    })
+    vi.mocked(commands.getDroidLaunchCommand).mockResolvedValue({
+      status: 'ok',
+      data: ['droid --settings "/home/user/.factory/settings.json"', ''],
+    })
+  })
+
+  it('launches Droid directly when the terminal launch succeeds', async () => {
+    const user = userEvent.setup()
+    render(<DroidFeatureList />)
+
+    const launchButton = await screen.findByTitle(
+      'Open Droid CLI in a new terminal window'
+    )
+    await user.click(launchButton)
+
+    await waitFor(() => {
+      expect(commands.launchDroid).toHaveBeenCalledTimes(1)
+    })
+    expect(commands.getDroidLaunchCommand).not.toHaveBeenCalled()
+    expect(writeTextMock).not.toHaveBeenCalled()
+    expect(toastMock.info).not.toHaveBeenCalled()
+    expect(toastMock.error).not.toHaveBeenCalled()
+  })
+
+  it('saves pending model changes before launching Droid', async () => {
+    const user = userEvent.setup()
+    const saveModels = vi.fn(async () => {
+      useModelStore.setState({ hasChanges: false })
+    })
+    useModelStore.setState({
+      hasChanges: true,
+      saveModels,
+    })
+
+    render(<DroidFeatureList />)
+
+    const launchButton = await screen.findByTitle(
+      'Open Droid CLI in a new terminal window'
+    )
+    await user.click(launchButton)
+
+    await waitFor(() => {
+      expect(saveModels).toHaveBeenCalledTimes(1)
+      expect(commands.launchDroid).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('switches back to Models and shows an error when saving model changes hits a config parse error', async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({ droidSubView: 'settings' })
+    const saveModels = vi.fn(async () => {
+      useModelStore.setState({
+        configParseError: 'CONFIG_PARSE_ERROR: invalid json',
+      })
+    })
+    useModelStore.setState({
+      hasChanges: true,
+      saveModels,
+    })
+
+    render(<DroidFeatureList />)
+
+    const launchButton = await screen.findByTitle(
+      'Open Droid CLI in a new terminal window'
+    )
+    await user.click(launchButton)
+
+    await waitFor(() => {
+      expect(saveModels).toHaveBeenCalledTimes(1)
+    })
+    expect(commands.launchDroid).not.toHaveBeenCalled()
+    expect(commands.getDroidLaunchCommand).not.toHaveBeenCalled()
+    expect(useUIStore.getState().droidSubView).toBe('models')
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Could not launch Droid because model changes could not be saved'
+    )
+    expect(writeTextMock).not.toHaveBeenCalled()
+  })
+
+  it('shows a fallback error before aborting launch when model saving still fails without details', async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({ droidSubView: 'mcp' })
+    const saveModels = vi.fn().mockResolvedValue(undefined)
+    useModelStore.setState({
+      hasChanges: true,
+      saveModels,
+    })
+
+    render(<DroidFeatureList />)
+
+    const launchButton = await screen.findByTitle(
+      'Open Droid CLI in a new terminal window'
+    )
+    await user.click(launchButton)
+
+    await waitFor(() => {
+      expect(saveModels).toHaveBeenCalledTimes(1)
+    })
+    expect(commands.launchDroid).not.toHaveBeenCalled()
+    expect(commands.getDroidLaunchCommand).not.toHaveBeenCalled()
+    expect(useUIStore.getState().droidSubView).toBe('models')
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Could not launch Droid because model changes could not be saved'
+    )
+  })
+
+  it('copies the legacy launch command when direct launch fails', async () => {
+    const user = userEvent.setup()
+    vi.mocked(commands.launchDroid).mockResolvedValue({
+      status: 'error',
+      error: 'launch failed',
+    })
+    vi.mocked(commands.getDroidLaunchCommand).mockResolvedValue({
+      status: 'ok',
+      data: ['droid --settings "/tmp/runtime/droid/temporary-run.json"', ''],
+    })
+
+    render(<DroidFeatureList />)
+
+    const launchButton = await screen.findByTitle(
+      'Open Droid CLI in a new terminal window'
+    )
+    await user.click(launchButton)
+
+    await waitFor(() => {
+      expect(commands.getDroidLaunchCommand).toHaveBeenCalledTimes(1)
+      expect(writeTextMock).toHaveBeenCalledWith(
+        'droid --settings "/tmp/runtime/droid/temporary-run.json"'
+      )
+    })
+    expect(toastMock.info).toHaveBeenCalledWith(
+      'Command copied to clipboard: droid --settings "/tmp/runtime/droid/temporary-run.json"'
+    )
+    expect(toastMock.error).not.toHaveBeenCalled()
+  })
+
+  it('shows a generic error when both launch and fallback command retrieval fail', async () => {
+    const user = userEvent.setup()
+    vi.mocked(commands.launchDroid).mockResolvedValue({
+      status: 'error',
+      error: 'launch failed',
+    })
+    vi.mocked(commands.getDroidLaunchCommand).mockResolvedValue({
+      status: 'error',
+      error: 'command unavailable',
+    })
+
+    render(<DroidFeatureList />)
+
+    const launchButton = await screen.findByTitle(
+      'Open Droid CLI in a new terminal window'
+    )
+    await user.click(launchButton)
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith('Something went wrong')
+    })
+    expect(writeTextMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/droid/DroidFeatureList.tsx
+++ b/src/components/droid/DroidFeatureList.tsx
@@ -170,7 +170,20 @@ export function DroidFeatureList() {
     }
   }
 
+  const surfaceModelSaveFailure = () => {
+    setDroidSubView('models')
+    toast.error(t('droid.settingsFile.launchSaveFailed'))
+  }
+
   const handleLaunchDroid = async () => {
+    if (useModelStore.getState().hasChanges) {
+      await useModelStore.getState().saveModels()
+      if (useModelStore.getState().hasChanges) {
+        surfaceModelSaveFailure()
+        return
+      }
+    }
+
     const result = await commands.launchDroid()
     if (result.status === 'error') {
       // If launch fails, copy the command to clipboard instead


### PR DESCRIPTION
## Summary

This PR changes the Droid "Run" entry to launch from a temporary settings snapshot instead of mutating or directly depending on the live active settings file.

It also keeps the pre-launch UX reliable:
- save pending model edits before launching
- surface save failures and route the user back to the Models page instead of failing silently
- keep terminal preference behavior intact across platforms
- avoid macOS system-default launcher collisions by using unique temporary launch scripts

## Why

The current Droid run flow is tied to the live settings file. That makes ad-hoc launches less isolated, and it also means launch-time behavior can diverge from what the user sees in the UI if there are still unsaved model edits.

Launching from a temporary snapshot keeps the run isolated while preserving the rest of the user's environment and terminal preference.

## Implementation Notes

- add a `droid_runtime` temp-run planner in `droidgear-core`
- build a terminal launch spec from the temp-run plan instead of shelling out from a single static command string
- apply the existing default env policy during launch
- add frontend tests that cover launch success, save-before-launch, visible save-failure handling, and fallback command copy behavior

A tiny separate commit is included to fix a `clippy` lifetime warning in the TUI renderer so the repo still passes the full local check suite.

## Validation

- `npm audit fix`
- `npm run rust:fmt`
- `npm run format`
- `npm run check:all`
