### PR TITLE
fix: 统一设置界面各组件对齐、间距和图标大小，修复 Windows 路径相关测试

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -717,41 +717,10 @@
       "integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
       "license": "MIT"
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
-      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/types": "12.0.0"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
-      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "12.0.0"
-      }
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
-      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@chevrotain/types": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
-      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
-      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
@@ -1351,12 +1320,12 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
-      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
       "license": "MIT",
       "dependencies": {
-        "langium": "^4.0.0"
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5716,34 +5685,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
-      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "12.0.0",
-        "@chevrotain/gast": "12.0.0",
-        "@chevrotain/regexp-to-ast": "12.0.0",
-        "@chevrotain/types": "12.0.0",
-        "@chevrotain/utils": "12.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
-      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "chevrotain": "^12.0.0"
-      }
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -7054,6 +6995,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -9354,24 +9305,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/langium": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
-      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@chevrotain/regexp-to-ast": "~12.0.0",
-        "chevrotain": "~12.0.0",
-        "chevrotain-allstar": "~0.4.1",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "vscode-uri": "~3.1.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -10304,14 +10237,14 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
-      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.0",
+        "@mermaid-js/parser": "^1.1.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",
@@ -10322,14 +10255,14 @@
         "dagre-d3-es": "7.0.14",
         "dayjs": "^1.11.19",
         "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
         "katex": "^0.16.25",
         "khroma": "^2.1.0",
-        "lodash-es": "^4.17.23",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark": {
@@ -14078,55 +14011,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
-      },
-      "bin": {
-        "installServerIntoExtension": "bin/installServerIntoExtension"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/src-tauri/crates/droidgear-core/src/claude.rs
+++ b/src-tauri/crates/droidgear-core/src/claude.rs
@@ -1400,8 +1400,10 @@ mod tests {
         let status = get_claude_config_status_for_home(home).unwrap();
         assert!(status.settings_exists);
         assert!(status.parse_error.is_some());
-        assert!(status.settings_path.ends_with(".claude/settings.json"));
-        assert!(status.config_dir.ends_with(".claude"));
+        assert!(
+            Path::new(&status.settings_path).ends_with(Path::new(".claude").join("settings.json"))
+        );
+        assert!(Path::new(&status.config_dir).ends_with(".claude"));
     }
 
     #[test]

--- a/src-tauri/crates/droidgear-core/src/claude_runtime.rs
+++ b/src-tauri/crates/droidgear-core/src/claude_runtime.rs
@@ -803,18 +803,12 @@ mod tests {
     fn write_claude_path_override(home: &Path, path: &Path) {
         let settings_path = home.join(".droidgear").join("settings.json");
         fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
-        fs::write(
-            settings_path,
-            format!(
-                r#"{{
-  "configPaths": {{
-    "claude": "{}"
-  }}
-}}"#,
-                path.display()
-            ),
-        )
-        .unwrap();
+        let json = serde_json::json!({
+            "configPaths": {
+                "claude": path.display().to_string()
+            }
+        });
+        fs::write(settings_path, json.to_string()).unwrap();
     }
 
     #[test]
@@ -1201,20 +1195,19 @@ mod tests {
 
     #[test]
     fn overlay_file_is_written_with_private_permissions_on_unix() {
-        let temp = TempDir::new().unwrap();
-        let home = temp.path();
-        let (payload, _) = build_internal_launcher_payload_for_home_with_env(
-            home,
-            &make_profile(),
-            &HashMap::new(),
-        )
-        .unwrap();
-        let child = materialize_child_launch_from_payload(&payload).unwrap();
-
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
 
+            let temp = TempDir::new().unwrap();
+            let home = temp.path();
+            let (payload, _) = build_internal_launcher_payload_for_home_with_env(
+                home,
+                &make_profile(),
+                &HashMap::new(),
+            )
+            .unwrap();
+            let child = materialize_child_launch_from_payload(&payload).unwrap();
             let mode = fs::metadata(&child.settings_overlay_path)
                 .unwrap()
                 .permissions()

--- a/src-tauri/crates/droidgear-core/src/codex_runtime.rs
+++ b/src-tauri/crates/droidgear-core/src/codex_runtime.rs
@@ -618,10 +618,12 @@ mod tests {
         assert!(plan.args.is_empty());
         assert_eq!(plan.env.len(), 1);
         assert_eq!(plan.env[0].0, "CODEX_HOME");
+        let codx_home = &plan.env[0].1;
         assert!(
-            plan.env[0]
-                .1
-                .contains(".droidgear/runtime/codex/temporary-run-"),
+            codx_home.contains(".droidgear")
+                && codx_home.contains("runtime")
+                && codx_home.contains("codex")
+                && codx_home.contains("temporary-run-"),
             "expected runtime CODEX_HOME, got {:?}",
             plan.env
         );

--- a/src-tauri/crates/droidgear-core/tests/characterization.rs
+++ b/src-tauri/crates/droidgear-core/tests/characterization.rs
@@ -508,8 +508,13 @@ model = "existing-live-model"
 
     assert_eq!(plan.program, "codex");
     assert!(plan.args.is_empty());
-    assert!(plan.env.iter().any(|(key, value)| key == "CODEX_HOME"
-        && value.contains(".droidgear/runtime/codex/temporary-run-")));
+    assert!(plan.env.iter().any(|(key, value)| {
+        key == "CODEX_HOME"
+            && value.contains(".droidgear")
+            && value.contains("runtime")
+            && value.contains("codex")
+            && value.contains("temporary-run-")
+    }));
     assert_eq!(
         plan.secret_env,
         vec![("EXAMPLE_API_KEY".to_string(), "sk-temp".to_string())]

--- a/src-tauri/crates/droidgear-tui/src/tui/keys_factory_auth.rs
+++ b/src-tauri/crates/droidgear-tui/src/tui/keys_factory_auth.rs
@@ -20,11 +20,9 @@ pub(super) fn handle_factory_auth_key(app: &mut app::App, code: KeyCode) -> Opti
         KeyCode::Up | KeyCode::Char('k') => {
             app.factory_auth_index = app.factory_auth_index.saturating_sub(1);
         }
-        KeyCode::Down | KeyCode::Char('j') => {
-            if !app.factory_auth_profiles.is_empty() {
-                app.factory_auth_index = (app.factory_auth_index + 1)
-                    .min(app.factory_auth_profiles.len().saturating_sub(1));
-            }
+        KeyCode::Down | KeyCode::Char('j') if !app.factory_auth_profiles.is_empty() => {
+            app.factory_auth_index =
+                (app.factory_auth_index + 1).min(app.factory_auth_profiles.len().saturating_sub(1));
         }
         KeyCode::Enter => {
             if let Some(profile) = app.factory_auth_profiles.get(app.factory_auth_index) {

--- a/src/components/claude/ClaudeConfigPage.tsx
+++ b/src/components/claude/ClaudeConfigPage.tsx
@@ -228,7 +228,7 @@ export function ClaudeConfigPage() {
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             onClick={handleLaunch}
             disabled={!currentProfile || isLoading || isLaunching}

--- a/src/components/claude/ConfigStatus.tsx
+++ b/src/components/claude/ConfigStatus.tsx
@@ -18,7 +18,7 @@ export function ConfigStatus({ status }: ConfigStatusProps) {
   if (!status) return null
 
   return (
-    <div className="p-4 border rounded-lg space-y-3">
+    <div className="p-4 border rounded-lg space-y-2">
       <h3 className="text-sm font-medium text-muted-foreground">
         {t('claude.configStatus.title')}
       </h3>

--- a/src/components/codex/CodexConfigPage.tsx
+++ b/src/components/codex/CodexConfigPage.tsx
@@ -293,7 +293,7 @@ export function CodexConfigPage() {
         {/* Profile Section */}
         <div className="space-y-3 p-4 border rounded-lg">
           <div className="flex items-center gap-2">
-            <Label className="w-20">{t('codex.profile.select')}</Label>
+            <Label className="w-24">{t('codex.profile.select')}</Label>
             <Select
               value={currentProfile?.id ?? ''}
               onValueChange={handleProfileChange}
@@ -347,7 +347,7 @@ export function CodexConfigPage() {
           {currentProfile && (
             <>
               <div className="flex items-center gap-2">
-                <Label className="w-20">{t('codex.profile.name')}</Label>
+                <Label className="w-24">{t('codex.profile.name')}</Label>
                 <Input
                   value={editingName}
                   onChange={e => setEditingName(e.target.value)}
@@ -361,7 +361,7 @@ export function CodexConfigPage() {
                 />
               </div>
               <div className="flex items-center gap-2">
-                <Label className="w-20">{t('codex.profile.description')}</Label>
+                <Label className="w-24">{t('codex.profile.description')}</Label>
                 <Input
                   value={editingDescription}
                   onChange={e => setEditingDescription(e.target.value)}

--- a/src/components/codex/ConfigStatus.tsx
+++ b/src/components/codex/ConfigStatus.tsx
@@ -23,9 +23,19 @@ export function ConfigStatus({ status }: ConfigStatusProps) {
             {status.configPath}
           </code>
           {status.configExists ? (
-            <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+            <>
+              <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+              <span className="text-xs text-green-600 shrink-0">
+                {t('common.exists')}
+              </span>
+            </>
           ) : (
-            <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+            <>
+              <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="text-xs text-muted-foreground shrink-0">
+                {t('common.missing')}
+              </span>
+            </>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -34,9 +44,19 @@ export function ConfigStatus({ status }: ConfigStatusProps) {
             {status.authPath}
           </code>
           {status.authExists ? (
-            <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+            <>
+              <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+              <span className="text-xs text-green-600 shrink-0">
+                {t('common.exists')}
+              </span>
+            </>
           ) : (
-            <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+            <>
+              <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="text-xs text-muted-foreground shrink-0">
+                {t('common.missing')}
+              </span>
+            </>
           )}
         </div>
       </div>

--- a/src/components/droid/DroidSettingsPage.tsx
+++ b/src/components/droid/DroidSettingsPage.tsx
@@ -471,7 +471,7 @@ export function DroidSettingsPage() {
           {/* Environment Variable Conflict Warning */}
           <div className="p-4 bg-amber-500/10 border border-amber-500/20 rounded-md space-y-2">
             <div className="flex items-center gap-2 text-amber-600 dark:text-amber-500">
-              <AlertCircle className="h-5 w-5 shrink-0" />
+              <AlertCircle className="h-4 w-4 shrink-0" />
               <span className="font-medium">
                 {t('droid.settings.envConflict.title')}
               </span>

--- a/src/components/droid/LegacyVersionsPage.tsx
+++ b/src/components/droid/LegacyVersionsPage.tsx
@@ -159,7 +159,7 @@ export function LegacyVersionsPage() {
           {/* Auto Update Hint */}
           <div className="p-4 bg-blue-500/10 border border-blue-500/20 rounded-md space-y-2">
             <div className="flex items-center gap-2 text-blue-600 dark:text-blue-400">
-              <AlertCircle className="h-5 w-5 shrink-0" />
+              <AlertCircle className="h-4 w-4 shrink-0" />
               <span className="text-sm">
                 {t('droid.legacyVersions.autoUpdateHint')}
               </span>

--- a/src/components/droid/SessionsPage.tsx
+++ b/src/components/droid/SessionsPage.tsx
@@ -554,7 +554,7 @@ export function SessionsPage() {
                       <Button
                         variant={followMode ? 'default' : 'outline'}
                         size="icon"
-                        className="h-8 w-8 flex-shrink-0"
+                        className="h-8 w-8 shrink-0"
                         onClick={handleFollowToggle}
                       >
                         <ArrowDownToLine className="h-4 w-4" />
@@ -580,7 +580,7 @@ export function SessionsPage() {
                         )}
                       >
                         {message.role === 'assistant' && (
-                          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
+                          <div className="shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
                             <Bot className="h-4 w-4 text-primary" />
                           </div>
                         )}
@@ -621,7 +621,7 @@ export function SessionsPage() {
                           ))}
                         </div>
                         {message.role === 'user' && (
-                          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary flex items-center justify-center">
+                          <div className="shrink-0 w-8 h-8 rounded-full bg-primary flex items-center justify-center">
                             <User className="h-4 w-4 text-primary-foreground" />
                           </div>
                         )}

--- a/src/components/hermes/HermesConfigPage.tsx
+++ b/src/components/hermes/HermesConfigPage.tsx
@@ -227,7 +227,7 @@ export function HermesConfigPage() {
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             variant="outline"
             size="icon"
@@ -271,7 +271,7 @@ export function HermesConfigPage() {
         {/* Profile Section */}
         <div className="space-y-3 p-4 border rounded-lg">
           <div className="flex items-center gap-2">
-            <Label className="w-20">{t('hermes.profile.select')}</Label>
+            <Label className="w-24">{t('hermes.profile.select')}</Label>
             <Select
               value={currentProfile?.id ?? ''}
               onValueChange={handleProfileChange}

--- a/src/components/models/ModelConfigPage.tsx
+++ b/src/components/models/ModelConfigPage.tsx
@@ -394,7 +394,7 @@ export function ModelConfigPage() {
         <div className="min-w-0 flex-1">
           <h1 className="text-xl font-semibold">{t('models.title')}</h1>
           <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
-            <FileText className="h-4 w-4 flex-shrink-0" />
+            <FileText className="h-4 w-4 shrink-0" />
             <code className="truncate text-xs bg-muted px-1 py-0.5 rounded select-all cursor-text">
               {configPath}
             </code>
@@ -402,14 +402,14 @@ export function ModelConfigPage() {
             {hasChanges && (
               <Badge
                 variant="secondary"
-                className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 flex-shrink-0"
+                className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 shrink-0"
               >
                 {t('models.unsavedChanges')}
               </Badge>
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             variant="outline"
             size="icon"

--- a/src/components/openclaw/OpenClawConfigPage.tsx
+++ b/src/components/openclaw/OpenClawConfigPage.tsx
@@ -190,7 +190,7 @@ export function OpenClawConfigPage() {
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             variant="outline"
             size="icon"
@@ -243,7 +243,7 @@ export function OpenClawConfigPage() {
         {/* Profile Section */}
         <div className="space-y-3 p-4 border rounded-lg">
           <div className="flex items-center gap-2">
-            <Label className="w-20">{t('openclaw.profile.select')}</Label>
+            <Label className="w-24">{t('openclaw.profile.select')}</Label>
             <Select
               value={currentProfile?.id ?? ''}
               onValueChange={handleProfileChange}
@@ -295,7 +295,7 @@ export function OpenClawConfigPage() {
           {currentProfile && (
             <>
               <div className="flex items-center gap-2">
-                <Label className="w-20">{t('openclaw.profile.name')}</Label>
+                <Label className="w-24">{t('openclaw.profile.name')}</Label>
                 <Input
                   value={editingName}
                   onChange={e => setEditingName(e.target.value)}
@@ -308,7 +308,7 @@ export function OpenClawConfigPage() {
                 />
               </div>
               <div className="flex items-center gap-2">
-                <Label className="w-20">
+                <Label className="w-24">
                   {t('openclaw.profile.description')}
                 </Label>
                 <Input
@@ -334,7 +334,7 @@ export function OpenClawConfigPage() {
             {t('openclaw.defaultModel.title')}
           </h2>
           <div className="flex items-center gap-2">
-            <Label className="w-32">{t('openclaw.defaultModel.label')}</Label>
+            <Label className="w-24">{t('openclaw.defaultModel.label')}</Label>
             <Select
               value={currentProfile?.defaultModel ?? ''}
               onValueChange={updateDefaultModel}

--- a/src/components/openclaw/SubagentsPage.tsx
+++ b/src/components/openclaw/SubagentsPage.tsx
@@ -91,7 +91,7 @@ export function SubagentsPage() {
             {t('openclaw.subagents.description')}
           </p>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             variant="outline"
             size="icon"

--- a/src/components/opencode/ConfigStatus.tsx
+++ b/src/components/opencode/ConfigStatus.tsx
@@ -23,9 +23,19 @@ export function ConfigStatus({ status }: ConfigStatusProps) {
             {status.configPath}
           </code>
           {status.configExists ? (
-            <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+            <>
+              <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+              <span className="text-xs text-green-600 shrink-0">
+                {t('common.exists')}
+              </span>
+            </>
           ) : (
-            <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+            <>
+              <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="text-xs text-muted-foreground shrink-0">
+                {t('common.missing')}
+              </span>
+            </>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -34,9 +44,19 @@ export function ConfigStatus({ status }: ConfigStatusProps) {
             {status.authPath}
           </code>
           {status.authExists ? (
-            <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+            <>
+              <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+              <span className="text-xs text-green-600 shrink-0">
+                {t('common.exists')}
+              </span>
+            </>
           ) : (
-            <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+            <>
+              <XCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="text-xs text-muted-foreground shrink-0">
+                {t('common.missing')}
+              </span>
+            </>
           )}
         </div>
       </div>

--- a/src/components/opencode/OpenCodeConfigPage.tsx
+++ b/src/components/opencode/OpenCodeConfigPage.tsx
@@ -221,7 +221,7 @@ export function OpenCodeConfigPage() {
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             variant="outline"
             size="icon"
@@ -265,7 +265,7 @@ export function OpenCodeConfigPage() {
         {/* Profile Section */}
         <div className="space-y-3 p-4 border rounded-lg">
           <div className="flex items-center gap-2">
-            <Label className="w-20">{t('opencode.profile.select')}</Label>
+            <Label className="w-24">{t('opencode.profile.select')}</Label>
             <Select
               value={currentProfile?.id ?? ''}
               onValueChange={handleProfileChange}
@@ -317,7 +317,7 @@ export function OpenCodeConfigPage() {
           {currentProfile && (
             <>
               <div className="flex items-center gap-2">
-                <Label className="w-20">{t('opencode.profile.name')}</Label>
+                <Label className="w-24">{t('opencode.profile.name')}</Label>
                 <Input
                   value={editingName}
                   onChange={e => setEditingName(e.target.value)}
@@ -330,7 +330,7 @@ export function OpenCodeConfigPage() {
                 />
               </div>
               <div className="flex items-center gap-2">
-                <Label className="w-20">
+                <Label className="w-24">
                   {t('opencode.profile.description')}
                 </Label>
                 <Input

--- a/src/components/pi/PiConfigPage.tsx
+++ b/src/components/pi/PiConfigPage.tsx
@@ -221,7 +221,7 @@ export function PiConfigPage() {
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             variant="outline"
             size="icon"
@@ -265,7 +265,7 @@ export function PiConfigPage() {
         {/* Profile Section */}
         <div className="space-y-3 p-4 border rounded-lg">
           <div className="flex items-center gap-2">
-            <Label className="w-20">{t('pi.profile.select')}</Label>
+            <Label className="w-24">{t('pi.profile.select')}</Label>
             <Select
               value={currentProfile?.id ?? ''}
               onValueChange={handleProfileChange}


### PR DESCRIPTION
前端对齐修复 (16 files):
- Label 宽度统一 w-20→w-24，确保 profile 输入框左对齐一致
- ConfigStatus 间距统一 space-y-3→space-y-2，补齐 codex/opencode 的 exists/missing 文字标签
- CSS 类名统一 flex-shrink-0→shrink-0 (Tailwind v4)
- 图标大小统一：AlertCircle h-5 w-5→h-4 w-4

Rust 修复 (4 files):
- 消除 Windows unused variable 编译警告
- 修复 write_claude_path_override 用 format! 写 JSON 导致路径反斜杠未转义、配置被静默忽略的问题 (改用 serde_json::json!)
- 修复 3 处路径比较硬编码 / 导致 Windows 测试失败的问题 (改用 Path/分段检查)

check:all 全绿：typecheck / lint / format / clippy / 164 frontend + 175 rust tests