### PR TITLE
fix(ui): disable auto-substitutions on Textarea

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -6,6 +6,10 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       data-slot="textarea"
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="off"
+      spellCheck={false}
       className={cn(
         'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className


### PR DESCRIPTION
## Summary

Mirror the `Input` defaults on `Textarea` so the OS / browser no longer auto-replaces straight quotes with curly quotes, auto-capitalizes, auto-completes, or spell-checks user input.

## Why

The extraArgs / extraHeaders JSON editors in `ModelDialog` rely on ASCII straight quotes (`"`). On macOS, the system substitutes typed `"` with curly `“ ”`, breaking `JSON.parse`. The `Input` component already disables these substitutions; `Textarea` did not.

## Change

`src/components/ui/textarea.tsx`:
```tsx
<textarea
  data-slot="textarea"
  autoComplete="off"
  autoCorrect="off"
  autoCapitalize="off"
  spellCheck={false}
  ...
/>
```

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>