### PR TITLE
fix: prevent duplicate update installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4330,7 +4330,7 @@
       "version": "25.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
       "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -4575,9 +4575,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5399,9 +5399,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7539,7 +7539,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8883,7 +8882,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9235,7 +9234,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9256,7 +9254,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9277,7 +9274,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9298,7 +9294,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9319,7 +9314,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9340,7 +9334,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9361,7 +9354,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9382,7 +9374,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9403,7 +9394,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9424,7 +9414,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9445,7 +9434,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13247,7 +13235,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -14032,7 +14020,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/components/preferences/panes/GeneralPane.tsx
+++ b/src/components/preferences/panes/GeneralPane.tsx
@@ -38,6 +38,7 @@ export function GeneralPane() {
 
   // Read pending update from global store (set by auto-updater in App.tsx)
   const pendingUpdate = useUIStore(state => state.pendingUpdate)
+  const isUpdateInstalling = useUIStore(state => state.isUpdateInstalling)
 
   // Track if we've already triggered auto-check for pending update
   const hasAutoChecked = useRef(false)
@@ -180,6 +181,7 @@ export function GeneralPane() {
                   variant="default"
                   size="sm"
                   onClick={handleDownloadAndInstall}
+                  disabled={isUpdateInstalling}
                 >
                   {t('preferences.general.downloadAndInstall')}
                 </Button>

--- a/src/components/updates/UpdateNotificationContent.test.tsx
+++ b/src/components/updates/UpdateNotificationContent.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useUIStore } from '@/store/ui-store'
+import { UpdateNotificationContent } from './UpdateNotificationContent'
+
+const defaultProps = {
+  message: 'Update available: v1.2.2',
+  releaseUrl: 'https://example.com/releases/v1.2.2',
+  releaseLabel: 'View details',
+  installLabel: 'Install now',
+  laterLabel: 'Later',
+  onOpenRelease: vi.fn(),
+  onInstallNow: vi.fn(),
+  onLater: vi.fn(),
+}
+
+describe('UpdateNotificationContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useUIStore.setState({ isUpdateInstalling: false })
+  })
+
+  it('disables the install button while an update is installing', () => {
+    useUIStore.setState({ isUpdateInstalling: true })
+
+    render(<UpdateNotificationContent {...defaultProps} />)
+
+    expect(
+      screen.getByRole('button', { name: defaultProps.installLabel })
+    ).toBeDisabled()
+  })
+})

--- a/src/components/updates/UpdateNotificationContent.tsx
+++ b/src/components/updates/UpdateNotificationContent.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { useUIStore } from '@/store/ui-store'
 
 interface UpdateNotificationContentProps {
   message: string
@@ -21,6 +22,8 @@ export function UpdateNotificationContent({
   onInstallNow,
   onLater,
 }: UpdateNotificationContentProps) {
+  const isUpdateInstalling = useUIStore(state => state.isUpdateInstalling)
+
   return (
     <div className="pointer-events-auto flex w-full max-w-[min(100vw-2rem,420px)] flex-col gap-3 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-lg">
       <p className="text-sm leading-snug">{message}</p>
@@ -52,6 +55,7 @@ export function UpdateNotificationContent({
           type="button"
           size="sm"
           className="cursor-pointer"
+          disabled={isUpdateInstalling}
           onClick={event => {
             event.stopPropagation()
             onInstallNow()

--- a/src/services/updater.test.ts
+++ b/src/services/updater.test.ts
@@ -24,6 +24,7 @@ import {
   checkForUpdate,
   clearCachedUpdate,
   clearUpdateNotificationSnooze,
+  downloadAndInstallUpdate,
   dismissUpdateNotification,
   isUpdateNotificationSnoozed,
   showUpdateNotification,
@@ -36,7 +37,10 @@ describe('updater service', () => {
     vi.clearAllMocks()
     clearCachedUpdate()
     clearUpdateNotificationSnooze()
-    useUIStore.setState({ pendingUpdate: null })
+    useUIStore.setState({
+      pendingUpdate: null,
+      isUpdateInstalling: false,
+    })
 
     vi.mocked(commands.getUpdateChannel).mockResolvedValue({
       status: 'ok',
@@ -101,6 +105,38 @@ describe('updater service', () => {
       channel: 'portable',
       releaseUrl: buildReleaseUrl('0.5.4'),
     })
+  })
+
+  it('ignores duplicate install requests while an update is installing', async () => {
+    let finishInstall: () => void = () => undefined
+    const installPromise = new Promise<void>(resolve => {
+      finishInstall = resolve
+    })
+    const downloadAndInstall = vi.fn().mockReturnValue(installPromise)
+
+    vi.mocked(check).mockResolvedValue({
+      version: '0.5.4',
+      body: 'Managed release notes',
+      downloadAndInstall,
+    } as never)
+
+    const update = await checkForUpdate()
+    if (!update) {
+      throw new Error('Expected an update to be available')
+    }
+    useUIStore.getState().setPendingUpdate(update)
+
+    const firstInstall = downloadAndInstallUpdate()
+    const duplicateInstall = downloadAndInstallUpdate()
+
+    expect(useUIStore.getState().isUpdateInstalling).toBe(true)
+    expect(downloadAndInstall).toHaveBeenCalledTimes(1)
+
+    finishInstall()
+    await Promise.all([firstInstall, duplicateInstall])
+
+    expect(useUIStore.getState().isUpdateInstalling).toBe(false)
+    expect(downloadAndInstall).toHaveBeenCalledTimes(1)
   })
 
   it('shows update notifications via toast.custom and can force repeat', () => {

--- a/src/services/updater.ts
+++ b/src/services/updater.ts
@@ -201,12 +201,29 @@ async function openReleasePage(releaseUrl: string): Promise<void> {
  * Download and install the update with progress tracking
  */
 export async function downloadAndInstallUpdate(): Promise<void> {
-  const pendingUpdate = useUIStore.getState().pendingUpdate
+  const { pendingUpdate, isUpdateInstalling, setUpdateInstalling } =
+    useUIStore.getState()
   if (!pendingUpdate) {
     logger.error('No update available to install')
     return
   }
 
+  if (isUpdateInstalling) {
+    logger.debug('Update installation already in progress')
+    return
+  }
+
+  setUpdateInstalling(true)
+  try {
+    await performDownloadAndInstallUpdate(pendingUpdate)
+  } finally {
+    useUIStore.getState().setUpdateInstalling(false)
+  }
+}
+
+async function performDownloadAndInstallUpdate(
+  pendingUpdate: PendingUpdate
+): Promise<void> {
   const t = i18n.t.bind(i18n)
 
   if (pendingUpdate.channel === 'portable') {

--- a/src/store/ui-store.test.ts
+++ b/src/store/ui-store.test.ts
@@ -9,6 +9,7 @@ describe('UIStore', () => {
       rightSidebarVisible: true,
       commandPaletteOpen: false,
       preferencesOpen: false,
+      isUpdateInstalling: false,
     })
   })
 
@@ -58,5 +59,15 @@ describe('UIStore', () => {
 
     toggleCommandPalette()
     expect(useUIStore.getState().commandPaletteOpen).toBe(false)
+  })
+
+  it('tracks update installation state', () => {
+    const { setUpdateInstalling } = useUIStore.getState()
+
+    setUpdateInstalling(true)
+    expect(useUIStore.getState().isUpdateInstalling).toBe(true)
+
+    setUpdateInstalling(false)
+    expect(useUIStore.getState().isUpdateInstalling).toBe(false)
   })
 })

--- a/src/store/ui-store.ts
+++ b/src/store/ui-store.ts
@@ -54,6 +54,7 @@ interface UIState {
   channelsSubView: ChannelsSubView
   lastSpecExportPath: string | null
   pendingUpdate: PendingUpdate | null
+  isUpdateInstalling: boolean
   droidSettingsScrollTarget: string | null
   droidRefreshKey: number
   closeConfirmOpen: boolean
@@ -75,6 +76,7 @@ interface UIState {
   setLastSpecExportPath: (path: string) => void
   setPendingUpdate: (update: PendingUpdate | null) => void
   clearPendingUpdate: () => void
+  setUpdateInstalling: (installing: boolean) => void
   setDroidSettingsScrollTarget: (target: string | null) => void
   incrementDroidRefreshKey: () => void
   setCloseConfirmOpen: (open: boolean) => void
@@ -97,6 +99,7 @@ export const useUIStore = create<UIState>()(
         channelsSubView: 'detail',
         lastSpecExportPath: null,
         pendingUpdate: null,
+        isUpdateInstalling: false,
         droidSettingsScrollTarget: null,
         droidRefreshKey: 0,
         closeConfirmOpen: false,
@@ -195,6 +198,13 @@ export const useUIStore = create<UIState>()(
 
         clearPendingUpdate: () =>
           set({ pendingUpdate: null }, undefined, 'clearPendingUpdate'),
+
+        setUpdateInstalling: installing =>
+          set(
+            { isUpdateInstalling: installing },
+            undefined,
+            'setUpdateInstalling'
+          ),
 
         setDroidSettingsScrollTarget: target =>
           set(


### PR DESCRIPTION
## Summary

- track update installation state globally and disable both install buttons while an update is running
- guard the updater service so rapid clicks or clicks from different entry points cannot start duplicate installs
- add regression coverage for the service lock, UI state, and notification button
- refresh vulnerable transitive dependencies via npm audit fix

## Verification

- npm audit fix (0 vulnerabilities)
- npm run format
- npm run rust:fmt
- npm run check:all
- npm run tui:build
- npm run tauri -- build --bundles dmg --config {"bundle":{"createUpdaterArtifacts":false}}
- hdiutil verify src-tauri/target/release/bundle/dmg/DroidGear_1.2.1_aarch64.dmg

The standard updater-enabled Tauri build produced the app, DMG, and updater archive, then stopped at updater signing because TAURI_SIGNING_PRIVATE_KEY is only available in the release workflow. The local DMG build disabled updater artifacts through a temporary CLI config override and completed successfully.