### PR TITLE
feat(codex): support MiMo model catalog for Codex + OpenAI protocol inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ xattr -cr /Applications/DroidGear.app
 - **Codex CLI 集成** - Codex 配置 Profile 管理
 - **认证配置** - 官方登录与 BYOK 认证配置文件的保存、切换及冲突检测
 - **即时应用** - 编辑当前活动的 Profile 时立即应用（含切换 Provider），无需手动应用
-- **模型目录同步** - 应用 DeepSeek V4 模型时自动同步 `~/.codex/models.json` 模型目录
+- **模型目录同步** - 应用 DeepSeek V4 / MiMo 模型时自动同步 `~/.codex/model-catalogs/` 下的分族模型目录（`model_catalog_json` 随模型族切换）
 - **配置管理** - 认证与 `config.toml` 的加载和保存（`~/.codex`）
 - **管理入口** - 在 Codex 入口下提供 MCP 服务器 / 会话 / 终端 管理子页
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -100,7 +100,7 @@ Run the installer directly.
 - **Codex CLI Integration** - Manage Codex configuration profiles
 - **Auth Profiles** - Save and switch between official login and BYOK auth profiles with conflict detection
 - **Instant Apply** - Edits to the currently active profile (including provider switches) apply immediately, no explicit apply needed
-- **Model Catalog Sync** - Applying DeepSeek V4 models automatically syncs the `~/.codex/models.json` model catalog
+- **Model Catalog Sync** - Applying DeepSeek V4 / MiMo models automatically syncs per-family catalogs under `~/.codex/model-catalogs/` (with `model_catalog_json` switched per family)
 - **Configuration Management** - Load and save auth/config.toml (`~/.codex`)
 - **Management Pages** - MCP servers / sessions / terminal subpages under Codex
 

--- a/src-tauri/crates/droidgear-core/res/codex-mimo-models.json
+++ b/src-tauri/crates/droidgear-core/res/codex-mimo-models.json
@@ -1,0 +1,81 @@
+{
+  "models": [
+    {
+      "slug": "mimo-v2.5-pro",
+      "display_name": "mimo-v2.5-pro",
+      "description": "MiMo-v2.5-Pro: Trillion-parameter Flagship Agent Foundation",
+      "default_reasoning_level": "high",
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "Disable Thinking"
+        },
+        {
+          "effort": "high",
+          "description": "Enabled Thinking"
+        }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 0,
+      "base_instructions": "You are MiMo, an AI assistant developed by Xiaomi. Today's date: {date} {week}. Your knowledge cutoff date is December 2024.",
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": false,
+      "truncation_policy": {
+        "mode": "bytes",
+        "limit": 10000
+      },
+      "supports_parallel_tool_calls": false,
+      "supports_image_detail_original": false,
+      "context_window": 1048576,
+      "max_context_window": 1048576,
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": [
+        "text"
+      ],
+      "supports_search_tool": false
+    },
+    {
+      "slug": "mimo-v2.5",
+      "display_name": "mimo-v2.5",
+      "description": "MiMo-V2.5: Native Omni-modal Perception Model",
+      "default_reasoning_level": "high",
+      "supported_reasoning_levels": [
+        {
+          "effort": "none",
+          "description": "Disable Thinking"
+        },
+        {
+          "effort": "high",
+          "description": "Enabled Thinking"
+        }
+      ],
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 1,
+      "base_instructions": "You are MiMo, an AI assistant developed by Xiaomi. Today's date: {date} {week}. Your knowledge cutoff date is December 2024.",
+      "supports_reasoning_summaries": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": false,
+      "truncation_policy": {
+        "mode": "bytes",
+        "limit": 10000
+      },
+      "supports_parallel_tool_calls": false,
+      "supports_image_detail_original": true,
+      "context_window": 1048576,
+      "max_context_window": 1048576,
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "supports_search_tool": false
+    }
+  ]
+}

--- a/src-tauri/crates/droidgear-core/src/codex.rs
+++ b/src-tauri/crates/droidgear-core/src/codex.rs
@@ -24,9 +24,18 @@ pub(crate) const OPENAI_API_KEY_FIELD: &str = "OPENAI_API_KEY";
 /// DeepSeek setup script (codex-deepseek-setup.sh).
 const DEEPSEEK_V4_MODELS: [&str; 2] = ["deepseek-v4-flash", "deepseek-v4-pro"];
 
+/// MiMo models that require the Codex model catalog file. Content mirrors
+/// the official MiMo Codex docs
+/// (mimo.mi.com/docs/zh-CN/tokenplan/integration/codex-configuration).
+const MIMO_MODELS: [&str; 2] = ["mimo-v2.5-pro", "mimo-v2.5"];
+
 /// Model catalog content for the DeepSeek V4 models, extracted verbatim
 /// from the official setup script.
 const CODEX_MODELS_JSON: &str = include_str!("../res/codex-models.json");
+
+/// Model catalog content for the MiMo models, extracted verbatim from the
+/// official MiMo Codex docs.
+const MIMO_MODELS_JSON: &str = include_str!("../res/codex-mimo-models.json");
 
 /// Codex Provider 配置（对应 config.toml 中的 [model_providers.<id>]）
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -175,24 +184,82 @@ fn now_rfc3339() -> String {
 // TOML helpers
 // ============================================================================
 
-/// Whether `model` is a DeepSeek V4 model that needs the Codex model
-/// catalog file.
-pub(crate) fn is_deepseek_v4_model(model: &str) -> bool {
-    DEEPSEEK_V4_MODELS.iter().any(|m| model.trim() == *m)
+/// Model family that needs a Codex model catalog file
+/// (`model_catalog_json` in config.toml). Each family keeps its own catalog
+/// under `~/.codex/model-catalogs/` so Codex only lists models that the
+/// configured endpoint actually serves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelCatalog {
+    DeepSeek,
+    Mimo,
 }
 
-/// Write the DeepSeek model catalog (`~/.codex/models.json`) when the active
-/// model needs it, otherwise remove it. Codex only reads this file via the
-/// `model_catalog_json` config key, so an orphaned catalog would be dead
-/// weight — and a dangling reference would break startup.
+impl ModelCatalog {
+    /// Catalog file name under `~/.codex/model-catalogs/`.
+    fn file_name(self) -> &'static str {
+        match self {
+            ModelCatalog::DeepSeek => "deepseek.json",
+            ModelCatalog::Mimo => "mimo.json",
+        }
+    }
+
+    /// Catalog content for this family.
+    fn content(self) -> &'static str {
+        match self {
+            ModelCatalog::DeepSeek => CODEX_MODELS_JSON,
+            ModelCatalog::Mimo => MIMO_MODELS_JSON,
+        }
+    }
+}
+
+/// Whether `model` belongs to a family that needs the Codex model catalog,
+/// and which one.
+pub(crate) fn catalog_for_model(model: &str) -> Option<ModelCatalog> {
+    let model = model.trim();
+    if DEEPSEEK_V4_MODELS.contains(&model) {
+        Some(ModelCatalog::DeepSeek)
+    } else if MIMO_MODELS.contains(&model) {
+        Some(ModelCatalog::Mimo)
+    } else {
+        None
+    }
+}
+
+/// Value for `model_catalog_json` in config.toml: `~/.codex/model-catalogs/<family>.json`
+/// when the codex home is the default `~/.codex`, otherwise the absolute
+/// path so a custom codex home does not dangle.
+fn model_catalog_json_value_for_home(
+    home_dir: &Path,
+    catalog: ModelCatalog,
+) -> Result<String, String> {
+    let config_paths = paths::load_config_paths_for_home(home_dir);
+    let codex_home = paths::get_codex_home_for_home(home_dir, &config_paths)?;
+    let rel = format!("model-catalogs/{}", catalog.file_name());
+    if codex_home == home_dir.join(".codex") {
+        Ok(format!("~/.codex/{rel}"))
+    } else {
+        Ok(codex_home.join(rel).to_string_lossy().into_owned())
+    }
+}
+
+/// Write the model catalog for the active model's family under
+/// `~/.codex/model-catalogs/`, and remove the legacy single-file catalog
+/// (`~/.codex/models.json`) written by older releases. Codex only reads a
+/// catalog via the `model_catalog_json` config key, so an orphaned catalog
+/// would be dead weight — and a dangling reference would break startup.
 pub fn sync_models_json_for_home(home_dir: &Path, model: &str) -> Result<(), String> {
-    let models_path = codex_config_dir_for_home(home_dir)?.join("models.json");
-    if is_deepseek_v4_model(model) {
-        storage::atomic_write(&models_path, CODEX_MODELS_JSON.as_bytes())
-            .map_err(|e| format!("Failed to write codex models.json: {e}"))?;
-    } else if models_path.exists() {
-        std::fs::remove_file(&models_path)
-            .map_err(|e| format!("Failed to remove codex models.json: {e}"))?;
+    let codex_dir = codex_config_dir_for_home(home_dir)?;
+
+    let legacy_models_path = codex_dir.join("models.json");
+    if legacy_models_path.exists() {
+        std::fs::remove_file(&legacy_models_path)
+            .map_err(|e| format!("Failed to remove legacy codex models.json: {e}"))?;
+    }
+
+    if let Some(catalog) = catalog_for_model(model) {
+        let catalog_path = codex_dir.join("model-catalogs").join(catalog.file_name());
+        storage::atomic_write(&catalog_path, catalog.content().as_bytes())
+            .map_err(|e| format!("Failed to write codex model catalog: {e}"))?;
     }
     Ok(())
 }
@@ -314,6 +381,7 @@ pub(crate) fn resolved_api_key(
 pub(crate) fn apply_profile_to_config_map(
     config: &mut toml::map::Map<String, toml::Value>,
     profile: &CodexProfile,
+    home_dir: &Path,
 ) -> Result<(), String> {
     let (effective_provider_id, active_provider) = resolve_active_provider(profile);
     let resolved_model = resolved_model(profile, active_provider);
@@ -354,15 +422,19 @@ pub(crate) fn apply_profile_to_config_map(
         );
     }
 
-    // DeepSeek V4 models load their model catalog from models.json; other
-    // models must not reference it, or Codex looks for a missing file.
-    if is_deepseek_v4_model(&resolved_model) {
-        config.insert(
-            "model_catalog_json".to_string(),
-            toml::Value::String("~/.codex/models.json".to_string()),
-        );
-    } else {
-        config.remove("model_catalog_json");
+    // Model families that ship a catalog (DeepSeek V4, MiMo) point
+    // model_catalog_json at their per-family catalog under model-catalogs/;
+    // other models must not reference it, or Codex looks for a missing file.
+    match catalog_for_model(&resolved_model) {
+        Some(catalog) => {
+            config.insert(
+                "model_catalog_json".to_string(),
+                toml::Value::String(model_catalog_json_value_for_home(home_dir, catalog)?),
+            );
+        }
+        None => {
+            config.remove("model_catalog_json");
+        }
     }
 
     Ok(())
@@ -790,7 +862,7 @@ pub fn apply_codex_profile_config_only_for_home(home_dir: &Path, id: &str) -> Re
         toml::map::Map::new()
     };
 
-    apply_profile_to_config_map(&mut config, &profile)?;
+    apply_profile_to_config_map(&mut config, &profile, home_dir)?;
 
     let toml_str = toml::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config.toml: {e}"))?;
@@ -831,7 +903,7 @@ pub fn apply_codex_profile_for_home(home_dir: &Path, id: &str) -> Result<(), Str
         toml::map::Map::new()
     };
 
-    apply_profile_to_config_map(&mut config, &profile)?;
+    apply_profile_to_config_map(&mut config, &profile, home_dir)?;
 
     let toml_str = toml::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config.toml: {e}"))?;
@@ -1016,10 +1088,10 @@ pub fn read_codex_current_config() -> Result<CodexCurrentConfig, String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_codex_profile_for_home, apply_profile_to_config_map, is_deepseek_v4_model,
+        apply_codex_profile_for_home, apply_profile_to_config_map, catalog_for_model,
         provider_config_to_toml, resolve_active_provider, resolve_codex_profile_selector_for_home,
         save_codex_profile_for_home, save_codex_profile_for_home_and_apply_if_active,
-        sync_models_json_for_home, CodexProfile, CodexProviderConfig,
+        sync_models_json_for_home, CodexProfile, CodexProviderConfig, ModelCatalog,
     };
     use std::collections::HashMap;
     use tempfile::TempDir;
@@ -1139,12 +1211,13 @@ mod tests {
             auth_profile_name: None,
         };
 
+        let temp = TempDir::new().unwrap();
         let mut config = toml::map::Map::new();
         config.insert(
             "model_providers".to_string(),
             toml::Value::Table(toml::map::Map::new()),
         );
-        apply_profile_to_config_map(&mut config, &profile).unwrap();
+        apply_profile_to_config_map(&mut config, &profile, temp.path()).unwrap();
 
         assert_eq!(
             config.get("model_provider").and_then(|v| v.as_str()),
@@ -1207,33 +1280,83 @@ mod tests {
     }
 
     #[test]
-    fn is_deepseek_v4_model_matches_flash_and_pro() {
-        assert!(is_deepseek_v4_model("deepseek-v4-flash"));
-        assert!(is_deepseek_v4_model("deepseek-v4-pro"));
-        assert!(is_deepseek_v4_model("  deepseek-v4-flash  "));
-        assert!(!is_deepseek_v4_model("gpt-5"));
-        assert!(!is_deepseek_v4_model("deepseek-chat"));
-        assert!(!is_deepseek_v4_model(""));
+    fn catalog_for_model_matches_deepseek_and_mimo_families() {
+        assert_eq!(
+            catalog_for_model("deepseek-v4-flash"),
+            Some(ModelCatalog::DeepSeek)
+        );
+        assert_eq!(
+            catalog_for_model("deepseek-v4-pro"),
+            Some(ModelCatalog::DeepSeek)
+        );
+        assert_eq!(
+            catalog_for_model("  deepseek-v4-flash  "),
+            Some(ModelCatalog::DeepSeek)
+        );
+        assert_eq!(catalog_for_model("mimo-v2.5-pro"), Some(ModelCatalog::Mimo));
+        assert_eq!(catalog_for_model("mimo-v2.5"), Some(ModelCatalog::Mimo));
+        assert_eq!(catalog_for_model("  mimo-v2.5  "), Some(ModelCatalog::Mimo));
+        assert_eq!(catalog_for_model("gpt-5"), None);
+        assert_eq!(catalog_for_model("deepseek-chat"), None);
+        assert_eq!(catalog_for_model(""), None);
     }
 
     #[test]
-    fn sync_models_json_writes_for_deepseek_v4_and_removes_otherwise() {
+    fn sync_models_json_writes_per_family_catalog_and_cleans_legacy() {
         let temp = TempDir::new().unwrap();
         let home = temp.path();
 
+        // DeepSeek V4 writes the deepseek family catalog under model-catalogs/.
         sync_models_json_for_home(home, "deepseek-v4-flash").unwrap();
-        let models_path = home.join(".codex").join("models.json");
-        assert!(models_path.exists());
-        let content = std::fs::read_to_string(&models_path).unwrap();
+        let deepseek_path = home
+            .join(".codex")
+            .join("model-catalogs")
+            .join("deepseek.json");
+        assert!(deepseek_path.exists());
+        let content = std::fs::read_to_string(&deepseek_path).unwrap();
         assert!(content.contains("deepseek-v4-flash"));
         assert!(content.contains("deepseek-v4-pro"));
+        assert!(!home
+            .join(".codex")
+            .join("model-catalogs")
+            .join("mimo.json")
+            .exists());
 
-        sync_models_json_for_home(home, "gpt-5").unwrap();
-        assert!(!models_path.exists());
+        // MiMo writes its own family catalog; the deepseek one stays put.
+        sync_models_json_for_home(home, "mimo-v2.5-pro").unwrap();
+        let mimo_path = home.join(".codex").join("model-catalogs").join("mimo.json");
+        assert!(mimo_path.exists());
+        let mimo_content = std::fs::read_to_string(&mimo_path).unwrap();
+        assert!(mimo_content.contains("mimo-v2.5-pro"));
+        assert!(mimo_content.contains("mimo-v2.5"));
+        assert!(deepseek_path.exists(), "other family catalogs are kept");
 
-        // Missing file is a no-op when the model does not need the catalog.
+        // Non-catalog models do not touch family catalogs.
         sync_models_json_for_home(home, "gpt-5").unwrap();
-        assert!(!models_path.exists());
+        assert!(deepseek_path.exists());
+        assert!(mimo_path.exists());
+    }
+
+    #[test]
+    fn sync_models_json_removes_legacy_single_file_catalog() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path();
+
+        // Simulate a catalog written by an older release at ~/.codex/models.json.
+        let legacy_path = home.join(".codex").join("models.json");
+        std::fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+        std::fs::write(&legacy_path, b"{\"models\":[]}").unwrap();
+
+        sync_models_json_for_home(home, "deepseek-v4-flash").unwrap();
+        assert!(
+            !legacy_path.exists(),
+            "legacy models.json must be cleaned up"
+        );
+        assert!(home
+            .join(".codex")
+            .join("model-catalogs")
+            .join("deepseek.json")
+            .exists());
     }
 
     fn sample_profile_with_model(model: &str) -> CodexProfile {
@@ -1270,27 +1393,42 @@ mod tests {
     }
 
     #[test]
-    fn apply_profile_to_config_map_sets_catalog_for_deepseek_v4() {
+    fn apply_profile_to_config_map_sets_catalog_per_family() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path();
+
         let mut config = toml::map::Map::new();
-        apply_profile_to_config_map(&mut config, &sample_profile_with_model("deepseek-v4-flash"))
+        apply_profile_to_config_map(
+            &mut config,
+            &sample_profile_with_model("deepseek-v4-flash"),
+            home,
+        )
+        .unwrap();
+        assert_eq!(
+            config.get("model_catalog_json").and_then(|v| v.as_str()),
+            Some("~/.codex/model-catalogs/deepseek.json")
+        );
+
+        let mut config = toml::map::Map::new();
+        apply_profile_to_config_map(&mut config, &sample_profile_with_model("mimo-v2.5"), home)
             .unwrap();
         assert_eq!(
             config.get("model_catalog_json").and_then(|v| v.as_str()),
-            Some("~/.codex/models.json")
+            Some("~/.codex/model-catalogs/mimo.json")
         );
 
         let mut config = toml::map::Map::new();
         config.insert(
             "model_catalog_json".to_string(),
-            toml::Value::String("~/.codex/models.json".to_string()),
+            toml::Value::String("~/.codex/model-catalogs/deepseek.json".to_string()),
         );
-        apply_profile_to_config_map(&mut config, &sample_profile_with_model("gpt-5")).unwrap();
+        apply_profile_to_config_map(&mut config, &sample_profile_with_model("gpt-5"), home)
+            .unwrap();
         assert!(
             !config.contains_key("model_catalog_json"),
-            "non-DeepSeek models must not reference the catalog"
+            "models without a catalog must not reference one"
         );
     }
-
     #[test]
     fn save_active_profile_applies_immediately() {
         let temp = TempDir::new().unwrap();

--- a/src-tauri/crates/droidgear-core/src/codex_runtime.rs
+++ b/src-tauri/crates/droidgear-core/src/codex_runtime.rs
@@ -410,7 +410,7 @@ fn build_runtime_home_snapshot(
     validate_provider_id(&provider_id)?;
 
     let mut config = read_config_template(&live_codex_home.join("config.toml"))?;
-    codex::apply_profile_to_config_map(&mut config, profile)?;
+    codex::apply_profile_to_config_map(&mut config, profile, home_dir)?;
     write_config_snapshot(&runtime_home_path, &config)?;
 
     let live_auth = read_auth_template(&live_codex_home.join("auth.json"));

--- a/src/lib/model-protocol/channel-inferrers/general-inferrer.ts
+++ b/src/lib/model-protocol/channel-inferrers/general-inferrer.ts
@@ -23,6 +23,7 @@ export class GeneralInferrer implements ChannelInferrer {
     // 使用简单的模型名称推断
     if (modelId.startsWith('claude-')) return 'anthropic'
     if (modelId.startsWith('gpt-')) return 'openai'
+    if (modelId.toLowerCase().startsWith('mimo-')) return 'openai'
 
     // 其他返回 null，使用全局推断
     return null

--- a/src/lib/model-protocol/global-inference.test.ts
+++ b/src/lib/model-protocol/global-inference.test.ts
@@ -32,6 +32,12 @@ describe('inferProtocolFromModelId', () => {
     expect(inferProtocolFromModelId('deepseek-chat')).toBe('openai')
   })
 
+  it('identifies MiMo models as openai', () => {
+    expect(inferProtocolFromModelId('mimo-v2.5')).toBe('openai')
+    expect(inferProtocolFromModelId('mimo-v2.5-pro')).toBe('openai')
+    expect(inferProtocolFromModelId('mimo-v2-flash')).toBe('openai')
+  })
+
   it('returns openai-compatible for unknown models', () => {
     expect(inferProtocolFromModelId('llama-3')).toBe('openai-compatible')
     expect(inferProtocolFromModelId('unknown-model')).toBe('openai-compatible')

--- a/src/lib/model-protocol/global-inference.ts
+++ b/src/lib/model-protocol/global-inference.ts
@@ -21,6 +21,9 @@ export function inferProtocolFromModelId(modelId: string): ModelProtocol {
   // DeepSeek 系列 (OpenAI)
   if (lowerModelId.startsWith('deepseek-')) return 'openai'
 
+  // MiMo 系列 (Xiaomi, OpenAI 兼容)
+  if (lowerModelId.startsWith('mimo-')) return 'openai'
+
   // 默认使用 OpenAI 兼容协议
   return 'openai-compatible'
 }

--- a/src/lib/newapi-platform.ts
+++ b/src/lib/newapi-platform.ts
@@ -5,6 +5,7 @@ export const inferProviderForNewApi = (modelId: string): Provider => {
   const modelLower = modelId.toLowerCase()
   if (modelLower.startsWith('claude-')) return 'anthropic'
   if (modelLower.startsWith('deepseek-')) return 'openai'
+  if (modelLower.startsWith('mimo-')) return 'openai'
   if (modelLower.startsWith('gpt-') || /^o[134](-|$)/.test(modelLower))
     return 'openai'
   return 'generic-chat-completion-api'

--- a/src/lib/sub2api-platform.test.ts
+++ b/src/lib/sub2api-platform.test.ts
@@ -91,6 +91,10 @@ describe('inferProviderFromPlatformAndModel', () => {
     expect(inferProviderFromPlatformAndModel(null, 'gpt-3.5-turbo')).toBe(
       'openai'
     )
+    expect(inferProviderFromPlatformAndModel(null, 'mimo-v2.5')).toBe('openai')
+    expect(inferProviderFromPlatformAndModel(null, 'mimo-v2.5-pro')).toBe(
+      'openai'
+    )
   })
 
   it('handles case-insensitive model name matching', () => {

--- a/src/lib/sub2api-platform.ts
+++ b/src/lib/sub2api-platform.ts
@@ -33,6 +33,7 @@ export const inferProviderFromPlatformAndModel = (
   if (modelLower.startsWith('claude-')) return 'anthropic'
   if (modelLower.startsWith('gpt-') || /^o[134](-|$)/.test(modelLower))
     return 'openai'
+  if (modelLower.startsWith('mimo-')) return 'openai'
 
   // 3. Default to generic
   return 'generic-chat-completion-api'


### PR DESCRIPTION
## Summary

Codex CLI needs a model catalog for non-official models so it can list and drive them correctly. Previously DroidGear only handled DeepSeek V4 by writing a single `~/.codex/models.json`. This PR adds MiMo (Xiaomi) support and splits catalogs per model family.

## Changes

### Rust: per-family Codex model catalogs (`codex.rs`, `codex_runtime.rs`)
- Replace the `is_deepseek_v4_model` bool check with a `ModelCatalog` enum (`DeepSeek` / `Mimo`).
- Each family now writes its own catalog under `~/.codex/model-catalogs/<family>.json`:
  - `deepseek.json` (existing content, unchanged)
  - `mimo.json` (new, extracted verbatim from the official MiMo Codex docs: `mimo-v2.5-pro` + `mimo-v2.5`, 1M context, reasoning levels)
- `model_catalog_json` in `config.toml` now points at the active family's catalog (relative `~/.codex/...` for the default home, absolute path for custom `CODEX_HOME`) and is removed for models without a catalog.
- Legacy single-file `~/.codex/models.json` from older releases is cleaned up on apply.
- New resource: `res/codex-mimo-models.json`.

### Frontend: OpenAI protocol inference for `mimo-*` (`model-protocol`)
- Route `mimo-*` model IDs to the `openai` protocol in the global inference, general channel inferrer, new-api and sub2api platform inference paths, mirroring the existing `deepseek-*` handling.
- Tests added for the new prefix in `global-inference.test.ts` and `sub2api-platform.test.ts`.

## Verification
- Pre-commit checks all green (typecheck, eslint, prettier, rustfmt, clippy -D warnings).
- Frontend: 230 vitest tests pass.
- Rust: `droidgear-core` + `droidgear-tui` test suites pass (incl. new catalog split/cleanup tests).

## Notes
- DeepSeek Codex profiles keep using the `responses` wire API (default in the provider dialog); registry `platform` only affects non-Codex channels.